### PR TITLE
Add vocabulary exercises across lessons

### DIFF
--- a/public/components/exercise.html
+++ b/public/components/exercise.html
@@ -1,0 +1,9 @@
+<section class="card exercise mb-4">
+  <h3>Traduce / Traduku</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -176,6 +176,54 @@ h2 {
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
+/* Layout for vocabulary exercises */
+.exercise-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem 1rem;
+}
+
+.exercise-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.exercise-item .term {
+  flex: 0 0 40%;
+  text-align: right;
+  font-weight: bold;
+}
+
+.exercise-item .answer {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.exercise-item .feedback-icon {
+  width: 1.25rem;
+  text-align: center;
+}
+
+.is-valid {
+  border-color: #198754;
+}
+
+.is-invalid {
+  border-color: #dc3545;
+}
+
+@media (max-width: 600px) {
+  .exercise-grid {
+    grid-template-columns: 1fr;
+  }
+  .exercise-item .term {
+    text-align: left;
+  }
+}
+
 body {
   display: flex;
   flex-direction: column;

--- a/public/data/vocab.json
+++ b/public/data/vocab.json
@@ -1,0 +1,1070 @@
+{
+  "1": [
+    {
+      "term": "io",
+      "answer": "yo"
+    },
+    {
+      "term": "esser",
+      "answer": "ser / estar"
+    },
+    {
+      "term": "habitar",
+      "answer": "habitar, vivir"
+    },
+    {
+      "term": "appartamento",
+      "answer": "departamento, apartamento"
+    },
+    {
+      "term": "tu",
+      "answer": "tú"
+    },
+    {
+      "term": "es",
+      "answer": "eres / estás (forma del verbo \"esser\")"
+    },
+    {
+      "term": "illa",
+      "answer": "ella"
+    },
+    {
+      "term": "amica",
+      "answer": "amiga"
+    },
+    {
+      "term": "nos",
+      "answer": "nosotros/as"
+    },
+    {
+      "term": "parlar",
+      "answer": "hablar"
+    },
+    {
+      "term": "interlingua",
+      "answer": "interlingua (nombre del idioma)"
+    },
+    {
+      "term": "con",
+      "answer": "con"
+    },
+    {
+      "term": "gratia",
+      "answer": "gracia"
+    },
+    {
+      "term": "iste",
+      "answer": "este/a"
+    },
+    {
+      "term": "lingua",
+      "answer": "idioma"
+    },
+    {
+      "term": "facile",
+      "answer": "fácil"
+    },
+    {
+      "term": "comprender",
+      "answer": "comprender"
+    },
+    {
+      "term": "si",
+      "answer": "si (condicional)"
+    },
+    {
+      "term": "on",
+      "answer": "uno (pronombre impersonal)"
+    },
+    {
+      "term": "practicar",
+      "answer": "practicar"
+    },
+    {
+      "term": "cata",
+      "answer": "cada"
+    },
+    {
+      "term": "die",
+      "answer": "día"
+    },
+    {
+      "term": "usar",
+      "answer": "usar"
+    },
+    {
+      "term": "curso",
+      "answer": "curso"
+    },
+    {
+      "term": "meliorar",
+      "answer": "mejorar"
+    },
+    {
+      "term": "comprension",
+      "answer": "comprensión"
+    },
+    {
+      "term": "expression",
+      "answer": "expresión"
+    }
+  ],
+  "10": [
+    {
+      "term": "pasatempo",
+      "answer": "pasatiempo, hobby"
+    },
+    {
+      "term": "principal",
+      "answer": "principal, primordial"
+    },
+    {
+      "term": "jocar",
+      "answer": "jugar"
+    },
+    {
+      "term": "futbol",
+      "answer": "fútbol"
+    },
+    {
+      "term": "codificar",
+      "answer": "codificar, programar"
+    },
+    {
+      "term": "projecto",
+      "answer": "proyecto"
+    },
+    {
+      "term": "tempore liber",
+      "answer": "tiempo libre"
+    },
+    {
+      "term": "amicos",
+      "answer": "amigos"
+    },
+    {
+      "term": "fin de septimana",
+      "answer": "fin de semana"
+    },
+    {
+      "term": "biber",
+      "answer": "beber (forma “bibe” - yo bebo)"
+    },
+    {
+      "term": "subjecto",
+      "answer": "asunto, tema"
+    },
+    {
+      "term": "technologia",
+      "answer": "tecnología"
+    },
+    {
+      "term": "innovative",
+      "answer": "innovador"
+    },
+    {
+      "term": "idea",
+      "answer": "idea"
+    },
+    {
+      "term": "Python",
+      "answer": "Python (lenguage de programmation)"
+    },
+    {
+      "term": "JavaScript",
+      "answer": "JavaScript (lenguage de programmation)"
+    },
+    {
+      "term": "applicato web",
+      "answer": "aplicacion web"
+    },
+    {
+      "term": "automatisation",
+      "answer": "automatización"
+    },
+    {
+      "term": "facilita",
+      "answer": "facilitar"
+    },
+    {
+      "term": "vita quotidian",
+      "answer": "vida cotidiana"
+    },
+    {
+      "term": "explorar",
+      "answer": "explorar"
+    },
+    {
+      "term": "instrumento",
+      "answer": "instrumento"
+    }
+  ],
+  "2": [
+    {
+      "term": "matino",
+      "answer": "mañana"
+    },
+    {
+      "term": "eveliar",
+      "answer": "despertarse"
+    },
+    {
+      "term": "reguardar",
+      "answer": "mirar, observar"
+    },
+    {
+      "term": "horologio",
+      "answer": "reloj"
+    },
+    {
+      "term": "septe",
+      "answer": "siete"
+    },
+    {
+      "term": "poter",
+      "answer": "poder"
+    },
+    {
+      "term": "dormir",
+      "answer": "dormir"
+    },
+    {
+      "term": "prender",
+      "answer": "tomar, agarrar"
+    },
+    {
+      "term": "leger",
+      "answer": "leer"
+    },
+    {
+      "term": "generes",
+      "answer": "géneros"
+    },
+    {
+      "term": "rubie",
+      "answer": "rojo"
+    },
+    {
+      "term": "verde",
+      "answer": "verde"
+    },
+    {
+      "term": "blau",
+      "answer": "azul"
+    },
+    {
+      "term": "jalne",
+      "answer": "amarillo"
+    },
+    {
+      "term": "jacer",
+      "answer": "yacer, estar tendido"
+    },
+    {
+      "term": "lecto",
+      "answer": "cama"
+    },
+    {
+      "term": "audier",
+      "answer": "oír"
+    },
+    {
+      "term": "quando",
+      "answer": "cuando"
+    },
+    {
+      "term": "seniora",
+      "answer": "señora"
+    },
+    {
+      "term": "aperir",
+      "answer": "abrir"
+    },
+    {
+      "term": "porta",
+      "answer": "puerta"
+    },
+    {
+      "term": "matre",
+      "answer": "madre"
+    },
+    {
+      "term": "levar se",
+      "answer": "levantarse"
+    },
+    {
+      "term": "vader",
+      "answer": "ir"
+    },
+    {
+      "term": "cucina",
+      "answer": "cocina"
+    }
+  ],
+  "3": [
+    {
+      "term": "casa",
+      "answer": "casa"
+    },
+    {
+      "term": "dormitorio",
+      "answer": "dormitorio, habitación"
+    },
+    {
+      "term": "morbide",
+      "answer": "blando"
+    },
+    {
+      "term": "materasso",
+      "answer": "colchón"
+    },
+    {
+      "term": "cuscino",
+      "answer": "almohada"
+    },
+    {
+      "term": "sur",
+      "answer": "sobre, encima de"
+    },
+    {
+      "term": "ligno",
+      "answer": "madera"
+    },
+    {
+      "term": "quatro",
+      "answer": "cuatro"
+    },
+    {
+      "term": "sedia",
+      "answer": "silla"
+    },
+    {
+      "term": "elegante",
+      "answer": "elegante"
+    },
+    {
+      "term": "salon",
+      "answer": "sala, salón"
+    },
+    {
+      "term": "luminose",
+      "answer": "luminoso"
+    },
+    {
+      "term": "continer",
+      "answer": "contener"
+    },
+    {
+      "term": "sofa",
+      "answer": "sofá"
+    },
+    {
+      "term": "television",
+      "answer": "televisión"
+    },
+    {
+      "term": "catto",
+      "answer": "gato"
+    },
+    {
+      "term": "sub",
+      "answer": "debajo de"
+    },
+    {
+      "term": "durante",
+      "answer": "durante"
+    },
+    {
+      "term": "vespere",
+      "answer": "tarde, anochecer"
+    },
+    {
+      "term": "invitar",
+      "answer": "invitar"
+    },
+    {
+      "term": "amico",
+      "answer": "amigo"
+    },
+    {
+      "term": "parve",
+      "answer": "pequeño"
+    },
+    {
+      "term": "reunion",
+      "answer": "reunión"
+    },
+    {
+      "term": "cata",
+      "answer": "cada (repetido del texto previe, incluse pro completar)"
+    },
+    {
+      "term": "sabbato",
+      "answer": "sábado"
+    }
+  ],
+  "4": [
+    {
+      "term": "levar se",
+      "answer": "levantarse"
+    },
+    {
+      "term": "septe",
+      "answer": "siete"
+    },
+    {
+      "term": "vestir se",
+      "answer": "vestirse"
+    },
+    {
+      "term": "rapidemente",
+      "answer": "rápidamente"
+    },
+    {
+      "term": "camisa",
+      "answer": "camisa"
+    },
+    {
+      "term": "pantalones",
+      "answer": "pantalones"
+    },
+    {
+      "term": "comfortabile",
+      "answer": "cómodo"
+    },
+    {
+      "term": "mangiar",
+      "answer": "comer"
+    },
+    {
+      "term": "pan",
+      "answer": "pan"
+    },
+    {
+      "term": "lacte",
+      "answer": "leche"
+    },
+    {
+      "term": "parve",
+      "answer": "pequeño"
+    },
+    {
+      "term": "fructo",
+      "answer": "fruta"
+    },
+    {
+      "term": "jentaculo",
+      "answer": "desayuno"
+    },
+    {
+      "term": "octo",
+      "answer": "ocho"
+    },
+    {
+      "term": "officio",
+      "answer": "oficina"
+    },
+    {
+      "term": "autobus",
+      "answer": "colectivo, autobús"
+    },
+    {
+      "term": "arrivar",
+      "answer": "llegar"
+    },
+    {
+      "term": "medie",
+      "answer": "y media (hora)"
+    },
+    {
+      "term": "labor",
+      "answer": "trabajo"
+    },
+    {
+      "term": "comenciar",
+      "answer": "comenzar"
+    },
+    {
+      "term": "scriber",
+      "answer": "escribir"
+    },
+    {
+      "term": "relation",
+      "answer": "informe, reporte"
+    },
+    {
+      "term": "responder",
+      "answer": "responder"
+    },
+    {
+      "term": "e-posta",
+      "answer": "correo electrónico"
+    },
+    {
+      "term": "diligentia",
+      "answer": "diligencia, esmero"
+    },
+    {
+      "term": "practicar",
+      "answer": "practicar"
+    },
+    {
+      "term": "yoga",
+      "answer": "yoga"
+    },
+    {
+      "term": "studio",
+      "answer": "estudio, sala"
+    },
+    {
+      "term": "pois",
+      "answer": "luego, después"
+    },
+    {
+      "term": "pro",
+      "answer": "para"
+    },
+    {
+      "term": "durante",
+      "answer": "durante"
+    }
+  ],
+  "5": [
+    {
+      "term": "pizza",
+      "answer": "pizza"
+    },
+    {
+      "term": "formaggio",
+      "answer": "queso"
+    },
+    {
+      "term": "tomate",
+      "answer": "tomate"
+    },
+    {
+      "term": "parve",
+      "answer": "pequeño"
+    },
+    {
+      "term": "pizzeria",
+      "answer": "pizzería"
+    },
+    {
+      "term": "local",
+      "answer": "local"
+    },
+    {
+      "term": "menu",
+      "answer": "menú"
+    },
+    {
+      "term": "offerer",
+      "answer": "ofrecer"
+    },
+    {
+      "term": "diverse",
+      "answer": "diversos/as"
+    },
+    {
+      "term": "specialitate",
+      "answer": "especialidad"
+    },
+    {
+      "term": "pasta",
+      "answer": "pasta"
+    },
+    {
+      "term": "pesto",
+      "answer": "pesto"
+    },
+    {
+      "term": "gelato",
+      "answer": "helado"
+    },
+    {
+      "term": "artisanal",
+      "answer": "artesanal"
+    },
+    {
+      "term": "fin",
+      "answer": "fin"
+    },
+    {
+      "term": "prandio",
+      "answer": "almuerzo, comida"
+    },
+    {
+      "term": "biber",
+      "answer": "beber"
+    },
+    {
+      "term": "sovente",
+      "answer": "a menudo"
+    },
+    {
+      "term": "caffe",
+      "answer": "café"
+    },
+    {
+      "term": "calide",
+      "answer": "caliente"
+    },
+    {
+      "term": "cena",
+      "answer": "cena"
+    },
+    {
+      "term": "vices",
+      "answer": "veces"
+    },
+    {
+      "term": "prefere",
+      "answer": "preferir"
+    },
+    {
+      "term": "aqua",
+      "answer": "agua"
+    },
+    {
+      "term": "frigide",
+      "answer": "fría"
+    },
+    {
+      "term": "frigorifero",
+      "answer": "heladera, refrigerador"
+    },
+    {
+      "term": "clar",
+      "answer": "clara"
+    },
+    {
+      "term": "restaurante",
+      "answer": "restaurante"
+    },
+    {
+      "term": "venerdi",
+      "answer": "viernes"
+    },
+    {
+      "term": "gauder",
+      "answer": "disfrutar"
+    },
+    {
+      "term": "ambiente",
+      "answer": "ambiente"
+    },
+    {
+      "term": "amical",
+      "answer": "amistoso"
+    },
+    {
+      "term": "gastronomia",
+      "answer": "gastronomía"
+    },
+    {
+      "term": "excellente",
+      "answer": "excelente"
+    }
+  ],
+  "6": [
+    {
+      "term": "Buenos Aires",
+      "answer": "Buenos Aires"
+    },
+    {
+      "term": "citate",
+      "answer": "ciudad"
+    },
+    {
+      "term": "barrio",
+      "answer": "barrio, vecindario"
+    },
+    {
+      "term": "caracter",
+      "answer": "caracter, personalidad"
+    },
+    {
+      "term": "vibrante",
+      "answer": "vibrante"
+    },
+    {
+      "term": "museo",
+      "answer": "museo"
+    },
+    {
+      "term": "famoso",
+      "answer": "famoso"
+    },
+    {
+      "term": "National",
+      "answer": "Nacional"
+    },
+    {
+      "term": "historice",
+      "answer": "historicas"
+    },
+    {
+      "term": "se trova",
+      "answer": "se encuentra"
+    },
+    {
+      "term": "symbolo",
+      "answer": "simbolo"
+    },
+    {
+      "term": "transporte",
+      "answer": "transporte"
+    },
+    {
+      "term": "public",
+      "answer": "publico"
+    },
+    {
+      "term": "comprender",
+      "answer": "comprender, incluir"
+    },
+    {
+      "term": "trene",
+      "answer": "tren"
+    },
+    {
+      "term": "rapide",
+      "answer": "rapido"
+    },
+    {
+      "term": "connecte",
+      "answer": "conecta"
+    },
+    {
+      "term": "calles",
+      "answer": "calles"
+    },
+    {
+      "term": "animate",
+      "answer": "animado"
+    },
+    {
+      "term": "turista",
+      "answer": "turista"
+    },
+    {
+      "term": "Obelisco",
+      "answer": "Obelisco (monumento)"
+    },
+    {
+      "term": "libreria",
+      "answer": "libreria"
+    },
+    {
+      "term": "artesanal",
+      "answer": "artesanal"
+    }
+  ],
+  "7": [
+    {
+      "term": "clima",
+      "answer": "clima"
+    },
+    {
+      "term": "anno",
+      "answer": "año"
+    },
+    {
+      "term": "estate",
+      "answer": "verano"
+    },
+    {
+      "term": "grado",
+      "answer": "grado"
+    },
+    {
+      "term": "dies",
+      "answer": "días"
+    },
+    {
+      "term": "soleate",
+      "answer": "soleado"
+    },
+    {
+      "term": "ideal",
+      "answer": "ideal"
+    },
+    {
+      "term": "promenar",
+      "answer": "pasear"
+    },
+    {
+      "term": "parco",
+      "answer": "parque"
+    },
+    {
+      "term": "hiberno",
+      "answer": "invierno"
+    },
+    {
+      "term": "minus",
+      "answer": "menos"
+    },
+    {
+      "term": "pluvia",
+      "answer": "lluvia"
+    },
+    {
+      "term": "frequente",
+      "answer": "frecuente"
+    },
+    {
+      "term": "vento",
+      "answer": "viento"
+    },
+    {
+      "term": "frigide",
+      "answer": "frío"
+    },
+    {
+      "term": "intenso",
+      "answer": "intenso"
+    },
+    {
+      "term": "cielo",
+      "answer": "cielo"
+    },
+    {
+      "term": "clar",
+      "answer": "claro"
+    },
+    {
+      "term": "suave",
+      "answer": "suave"
+    },
+    {
+      "term": "vices",
+      "answer": "veces"
+    },
+    {
+      "term": "tempestate",
+      "answer": "tormenta"
+    },
+    {
+      "term": "rapidemente",
+      "answer": "rápidamente"
+    },
+    {
+      "term": "forte",
+      "answer": "fuerte"
+    },
+    {
+      "term": "intense",
+      "answer": "intenso (fem.)"
+    },
+    {
+      "term": "temperatura",
+      "answer": "temperatura"
+    },
+    {
+      "term": "variar",
+      "answer": "variar"
+    },
+    {
+      "term": "bastante",
+      "answer": "bastante"
+    },
+    {
+      "term": "require",
+      "answer": "requerir"
+    },
+    {
+      "term": "prepara",
+      "answer": "preparar"
+    },
+    {
+      "term": "vestimento",
+      "answer": "vestimenta, ropa"
+    },
+    {
+      "term": "situation",
+      "answer": "situación"
+    }
+  ],
+  "8": [
+    {
+      "term": "comprar",
+      "answer": "comprar"
+    },
+    {
+      "term": "grammatic",
+      "answer": "gramatica"
+    },
+    {
+      "term": "presentation",
+      "answer": "presentacion"
+    },
+    {
+      "term": "precio",
+      "answer": "precio, costo"
+    },
+    {
+      "term": "euro",
+      "answer": "euro"
+    },
+    {
+      "term": "systema",
+      "answer": "sistema"
+    },
+    {
+      "term": "digital",
+      "answer": "digital"
+    },
+    {
+      "term": "manda",
+      "answer": "enviar"
+    },
+    {
+      "term": "recibo",
+      "answer": "recibo"
+    },
+    {
+      "term": "cliente",
+      "answer": "cliente"
+    },
+    {
+      "term": "beneficiar se",
+      "answer": "beneficiarse"
+    },
+    {
+      "term": "desconto",
+      "answer": "descuento"
+    },
+    {
+      "term": "por cento",
+      "answer": "porcentaje (10 por cento = 10%)"
+    },
+    {
+      "term": "fidel",
+      "answer": "fiel"
+    },
+    {
+      "term": "pagar",
+      "answer": "pagar"
+    },
+    {
+      "term": "carta de credito",
+      "answer": "tarjeta de credito"
+    },
+    {
+      "term": "conservar",
+      "answer": "conservar"
+    },
+    {
+      "term": "futura",
+      "answer": "futuro/a"
+    },
+    {
+      "term": "referentia",
+      "answer": "referencia"
+    }
+  ],
+  "9": [
+    {
+      "term": "vade",
+      "answer": "ir"
+    },
+    {
+      "term": "treno",
+      "answer": "tren"
+    },
+    {
+      "term": "proxime",
+      "answer": "próximo"
+    },
+    {
+      "term": "venerdi",
+      "answer": "viernes"
+    },
+    {
+      "term": "trajecto",
+      "answer": "trayecto, recorrido"
+    },
+    {
+      "term": "circa",
+      "answer": "aproximadamente"
+    },
+    {
+      "term": "paisage",
+      "answer": "paisaje"
+    },
+    {
+      "term": "montanose",
+      "answer": "montañoso"
+    },
+    {
+      "term": "campo",
+      "answer": "campo"
+    },
+    {
+      "term": "sede",
+      "answer": "asiento"
+    },
+    {
+      "term": "sito web",
+      "answer": "sitio web"
+    },
+    {
+      "term": "official",
+      "answer": "oficial"
+    },
+    {
+      "term": "compania",
+      "answer": "compañía"
+    },
+    {
+      "term": "ferrovia",
+      "answer": "ferrocarril"
+    },
+    {
+      "term": "statione",
+      "answer": "estación"
+    },
+    {
+      "term": "organise",
+      "answer": "organizar"
+    },
+    {
+      "term": "cafe",
+      "answer": "café"
+    },
+    {
+      "term": "bottega",
+      "answer": "tienda, negocio"
+    },
+    {
+      "term": "information",
+      "answer": "información"
+    },
+    {
+      "term": "passagero",
+      "answer": "pasajero"
+    },
+    {
+      "term": "viage",
+      "answer": "viaje"
+    },
+    {
+      "term": "leje",
+      "answer": "leer"
+    },
+    {
+      "term": "musica",
+      "answer": "música"
+    },
+    {
+      "term": "passar",
+      "answer": "pasar"
+    },
+    {
+      "term": "tempore",
+      "answer": "tiempo"
+    }
+  ]
+}

--- a/public/js/exercises.js
+++ b/public/js/exercises.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('exercise-container');
+  if (!container) return;
+  const lesson = container.dataset.lesson;
+
+  const data = await fetch('/data/vocab.json').then(r => r.json());
+  const items = data[lesson] || [];
+
+  const template = await fetch('/components/exercise.html').then(r => r.text());
+  container.innerHTML = template;
+
+  const form = container.querySelector('#exercise-form');
+  items.forEach(({ term, answer }) => {
+    const item = document.createElement('div');
+    item.className = 'exercise-item';
+    item.innerHTML = `
+      <label class="term">${term}:</label>
+      <div class="answer">
+        <input type="text" data-answer="${answer}" class="exercise-input">
+        <span class="feedback-icon"></span>
+      </div>
+    `;
+    form.appendChild(item);
+  });
+
+  const btnCheck = container.querySelector('.btn-comprobar');
+  const btnClear = container.querySelector('.btn-borrar');
+  const feedback = container.querySelector('.feedback');
+
+  btnCheck.addEventListener('click', (e) => {
+    e.preventDefault();
+    let correct = 0;
+    const inputs = form.querySelectorAll('.exercise-input');
+    inputs.forEach(input => {
+      const expected = input.dataset.answer.trim().toLowerCase();
+      const val = input.value.trim().toLowerCase();
+      const icon = input.nextElementSibling;
+      if (val === expected) {
+        input.classList.add('is-valid');
+        input.classList.remove('is-invalid');
+        icon.innerHTML = '<i class="fa-solid fa-check text-success"></i>';
+        correct++;
+      } else {
+        input.classList.add('is-invalid');
+        input.classList.remove('is-valid');
+        icon.innerHTML = '<i class="fa-solid fa-times text-danger"></i>';
+      }
+    });
+    feedback.textContent = `✔️ ${correct}/${inputs.length}`;
+  });
+
+  btnClear.addEventListener('click', (e) => {
+    e.preventDefault();
+    const inputs = form.querySelectorAll('.exercise-input');
+    inputs.forEach(input => {
+      input.value = '';
+      input.classList.remove('is-valid', 'is-invalid');
+      const icon = input.nextElementSibling;
+      if (icon) icon.innerHTML = '';
+    });
+    feedback.textContent = '';
+  });
+});

--- a/public/lection/lection1.html
+++ b/public/lection/lection1.html
@@ -95,7 +95,10 @@
         </ul>
       </section>
 
-      <section class="exercise">
+      <div id="exercise-container" data-lesson="1"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
         <h3>Problema / Ejercicio</h3>
         <p>Traduce a interlingua:</p>
         <ul>

--- a/public/lection/lection10.html
+++ b/public/lection/lection10.html
@@ -84,7 +84,10 @@
             <li>Uso de **quando** para tiempo: <em>quando io ha plus tempore</em>.</li>
             </ul>
       </section>
-            <section class="exercise">
+            <div id="exercise-container" data-lesson="10"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
             <h3>Problema / Ejercicio</h3>
                 <p>Traducí al interlingua:<br>
                     <li>“Mi hobby favorito es la fotografía.”</li>

--- a/public/lection/lection2.html
+++ b/public/lection/lection2.html
@@ -86,7 +86,10 @@
             <li>Los adjetivos no varían en género ni número: un libro <strong>jalne</strong>, duo libros <strong>jalne</strong>.</li>
           </ul>
       </section>
-      <section class="exercise">
+      <div id="exercise-container" data-lesson="2"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
         <h3>Problema / Ejercicio</h3>
         <p>Respondé en interlingua:<br>
             <li>📖 ¿Es isto un libro?</li>

--- a/public/lection/lection3.html
+++ b/public/lection/lection3.html
@@ -87,7 +87,10 @@
             <li>Los adjetivos no varían en género ni número: un libro <strong>jalne</strong>, duo libros <strong>jalne</strong>.</li>
           </ul>
       </section>
-        <section class="exercise">
+        <div id="exercise-container" data-lesson="3"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
         <h3>Problema / Ejercicio</h3>
             <p>Traducí al interlingua:<br>
                 <li>“En mi sala hay un sofá y dos sillones.”</li>

--- a/public/lection/lection4.html
+++ b/public/lection/lection4.html
@@ -92,7 +92,10 @@
             <li>Infinitivo tras verbos de hábito: <strong>me leva</strong>, <strong>practica yoga</strong>, <strong>lege un libro</strong>.</li>
             </ul>
       </section>
-            <section class="exercise">
+            <div id="exercise-container" data-lesson="4"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
             <h3>Problema / Ejercicio</h3>
                 <p>Traducí al interlingua:<br>
                     <li>“Me levanto a las siete de la mañana.”</li>

--- a/public/lection/lection5.html
+++ b/public/lection/lection5.html
@@ -95,7 +95,10 @@
             <li>Para expresar preferencias se usa <strong>preferer</strong> + infinitivo: <em>io prefere aqua frige</em>, <em>ella preferi pasta al dente</em>.</li>
             </ul>
       </section>
-            <section class="exercise">
+            <div id="exercise-container" data-lesson="5"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
             <h3>Problema / Ejercicio</h3>
                 <p>Traducí al interlingua:<br>
                     <li>“Me gusta el helado de vainilla.”</li>

--- a/public/lection/lection6.html
+++ b/public/lection/lection6.html
@@ -84,7 +84,10 @@
             <li>Adjetivos de nacionalidad o estilo no varían: <em>historic</em>, <em>famoso</em>, <em>rapide</em>.</li>
             </ul>
       </section>
-        <section class="exercise">
+        <div id="exercise-container" data-lesson="6"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
         <h3>Problema / Ejercicio</h3>
             <p>Traducí al interlingua:<br>
                 <li>“En mi ciudad hay un parque y un museo.”</li>

--- a/public/lection/lection7.html
+++ b/public/lection/lection7.html
@@ -93,7 +93,10 @@
             <li>Para indicar frecuencia se usa <strong>a vices</strong> (a veces).</li>
             </ul>
       </section>
-        <section class="exercise">
+        <div id="exercise-container" data-lesson="7"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
         <h3>Problema / Ejercicio</h3>
             <p>Traducí al interlingua:<br>
                 <li>“Hoy está nublado.”</li>

--- a/public/lection/lection8.html
+++ b/public/lection/lection8.html
@@ -82,7 +82,10 @@
             <li>Adjetivo <strong>digital</strong> invariable: <em>sistema digital</em>, <em>recibo digital</em>.</li>
             </ul>
       </section>
-            <section class="exercise">
+            <div id="exercise-container" data-lesson="8"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
             <h3>Problema / Ejercicio</h3>
                 <p>Traducí al interlingua:<br>
                     <li>“Pago 100 euros por tres libros.”</li>

--- a/public/lection/lection9.html
+++ b/public/lection/lection9.html
@@ -87,7 +87,10 @@
             <li><strong>Durante</strong> para expresar simultaneidad: <em>durante le viage</em>.</li>
             </ul>
       </section>
-            <section class="exercise">
+            <div id="exercise-container" data-lesson="9"></div>
+<script src="/js/exercises.js"></script>
+
+<section class="exercise">
             <h3>Problema / Ejercicio</h3>
                 <p>Traducí al interlingua:<br>
                     <li>“Voy a viajar en avión mañana.”</li>


### PR DESCRIPTION
## Summary
- convert vocabulary tables to JSON dataset
- add shared vocabulary exercise component and script
- load vocabulary exercises in lessons 1–10
- refine vocabulary exercise layout using CSS grid for two-column display

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a711d9b5c832cb543bac6521f9f6e