### PR TITLE
Add tooltip demo page

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -292,3 +292,37 @@ main {
   display: inline-block;
   color: #fff;
 }
+
+/* Tooltips para vocabulario */
+.tooltip {
+  position: relative;
+  border-bottom: 1px dotted #555;
+  cursor: help;
+}
+
+.tooltiptext {
+  visibility: hidden;
+  background-color: #f9f9f9;
+  color: #000;
+  text-align: center;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 6px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+@media (max-width: 600px) {
+  .tooltiptext {
+    bottom: auto;
+    top: 125%;
+  }
+}

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -1,0 +1,32 @@
+// Agrega tooltips de traducción a todos los textos de las lecciones
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Cargar vocabulario
+  fetch('/data/vocab.json')
+    .then(res => res.json())
+    .then(data => {
+      const vocab = {};
+      // Unir todas las lecciones en un solo objeto de búsqueda
+      Object.values(data).forEach(arr => {
+        arr.forEach(({ term, answer }) => {
+          vocab[term.toLowerCase()] = answer;
+        });
+      });
+
+      const paragraphs = document.querySelectorAll('.text-block p');
+      paragraphs.forEach(p => {
+        const tokens = p.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
+        const html = tokens.map(tok => {
+          const clean = tok.replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
+          if (vocab[clean]) {
+            const translation = vocab[clean];
+            return `<span class="tooltip" aria-label="${translation}">${tok}<span class="tooltiptext">${translation}</span></span>`;
+          }
+          return tok;
+        }).join('');
+
+        p.innerHTML = html;
+      });
+    })
+    .catch(err => console.error('No se pudo cargar el vocabulario:', err));
+});

--- a/public/lection/lection1.html
+++ b/public/lection/lection1.html
@@ -106,6 +106,7 @@
     </div>
       <div id="exercise-container" data-lesson="1"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection10.html
+++ b/public/lection/lection10.html
@@ -97,6 +97,7 @@
     </div>
             <div id="exercise-container" data-lesson="10"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection2.html
+++ b/public/lection/lection2.html
@@ -100,6 +100,7 @@
     </div>
       <div id="exercise-container" data-lesson="2"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection3.html
+++ b/public/lection/lection3.html
@@ -100,6 +100,7 @@
     </div>
         <div id="exercise-container" data-lesson="3"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection4.html
+++ b/public/lection/lection4.html
@@ -105,6 +105,7 @@
     </div>
             <div id="exercise-container" data-lesson="4"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection5.html
+++ b/public/lection/lection5.html
@@ -108,6 +108,7 @@
     </div>
             <div id="exercise-container" data-lesson="5"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection6.html
+++ b/public/lection/lection6.html
@@ -97,6 +97,7 @@
     </div>
         <div id="exercise-container" data-lesson="6"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection7.html
+++ b/public/lection/lection7.html
@@ -106,6 +106,7 @@
     </div>
         <div id="exercise-container" data-lesson="7"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection8.html
+++ b/public/lection/lection8.html
@@ -95,6 +95,7 @@
     </div>
             <div id="exercise-container" data-lesson="8"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/lection/lection9.html
+++ b/public/lection/lection9.html
@@ -100,6 +100,7 @@
     </div>
             <div id="exercise-container" data-lesson="9"></div>
 <script src="/js/exercises.js"></script>
+<script src="/js/tooltip.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>

--- a/public/vocab_demo/index.html
+++ b/public/vocab_demo/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Schola Interlingua - Demo Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <p id="lesson-text">
+    Io es Maria e io habita in un appartamento in Buenos Aires. Es tu Juan? Illa es Ana, mi amica. Nos parla interlingua con gratia. Iste lingua es facile a comprender si on practica cata die. Nos usa iste curso pro meliorar nostre comprension e expression.
+  </p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/vocab_demo/script.js
+++ b/public/vocab_demo/script.js
@@ -1,0 +1,32 @@
+// Agrega tooltips de traducción al texto de la lección
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Carga el vocabulario
+  fetch('../data/vocab.json')
+    .then(response => response.json())
+    .then(data => {
+      const vocab = {};
+      // Combina todas las lecciones en un solo objeto para búsqueda rápida
+      Object.values(data).forEach(arr => {
+        arr.forEach(({ term, answer }) => {
+          vocab[term.toLowerCase()] = answer;
+        });
+      });
+
+      const lessonText = document.getElementById('lesson-text');
+      if (!lessonText) return;
+
+      const tokens = lessonText.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
+      const processed = tokens.map(tok => {
+        const clean = tok.replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
+        if (vocab[clean]) {
+          const translation = vocab[clean];
+          return `<span class="tooltip" aria-label="${translation}">${tok}<span class="tooltiptext">${translation}</span></span>`;
+        }
+        return tok;
+      });
+
+      lessonText.innerHTML = processed.join('');
+    })
+    .catch(err => console.error('No se pudo cargar el vocabulario:', err));
+});

--- a/public/vocab_demo/style.css
+++ b/public/vocab_demo/style.css
@@ -1,0 +1,33 @@
+/* Estilos para tooltips de vocabulario */
+.tooltip {
+  position: relative;
+  border-bottom: 1px dotted #555;
+  cursor: help;
+}
+
+.tooltiptext {
+  visibility: hidden;
+  background-color: #f9f9f9;
+  color: #000;
+  text-align: center;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 6px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+@media (max-width: 600px) {
+  .tooltiptext {
+    bottom: auto;
+    top: 125%;
+  }
+}


### PR DESCRIPTION
## Summary
- add demo page for vocabulary translation tooltips
- add tooltip logic to every lesson's `.text-block`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688b95d0e714832cbcb8799ae59a7118