### PR TITLE
Implement multilingual vocab structure and clean HTML

### DIFF
--- a/public/appendice/contos.html
+++ b/public/appendice/contos.html
@@ -13,8 +13,6 @@
   <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
 </head>
 <body>
-</head>
-<body>
   <!-- Navbar externo -->
   <nav></nav>
   <main>

--- a/public/components/navbar.html
+++ b/public/components/navbar.html
@@ -28,6 +28,13 @@
           <li><a href="/appendice/contos.html">Contos legite</a></li>
         </ul>
       </li>
+      <li class="dropdown">
+        <a href="#">Idioma ▼</a>
+        <ul class="dropdown-menu">
+          <li><a href="#" class="lang-option" data-lang="es">Español</a></li>
+          <li><a href="#" class="lang-option" data-lang="en">English</a></li>
+        </ul>
+      </li>
     </ul>
   </div>
 </header>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -326,3 +326,20 @@ main {
     top: 125%;
   }
 }
+
+/* Botón para desplegar tabla de vocabulario */
+.vocab-toggle {
+  display: inline-block;
+  margin: 1rem 0;
+  padding: 0.6rem 1.5rem;
+  font-size: 1.1rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.vocab-toggle:hover {
+  background: #0a3a63;
+}

--- a/public/data/vocab.json
+++ b/public/data/vocab.json
@@ -2,1065 +2,1327 @@
   "1": [
     {
       "term": "io",
-      "answer": "yo"
+      "es": "yo",
+      "en": "I"
     },
     {
       "term": "esser",
-      "answer": "ser / estar"
+      "es": "ser / estar",
+      "en": "to be"
     },
     {
       "term": "habitar",
-      "answer": "habitar, vivir"
+      "es": "habitar, vivir",
+      "en": "to live"
     },
     {
       "term": "appartamento",
-      "answer": "departamento, apartamento"
+      "es": "departamento, apartamento",
+      "en": "apartment"
     },
     {
       "term": "tu",
-      "answer": "tú"
+      "es": "tú",
+      "en": "you"
     },
     {
       "term": "es",
-      "answer": "eres / estás (forma del verbo \"esser\")"
+      "es": "eres / estás (forma del verbo \"esser\")",
+      "en": ""
     },
     {
       "term": "illa",
-      "answer": "ella"
+      "es": "ella",
+      "en": ""
     },
     {
       "term": "amica",
-      "answer": "amiga"
+      "es": "amiga",
+      "en": ""
     },
     {
       "term": "nos",
-      "answer": "nosotros/as"
+      "es": "nosotros/as",
+      "en": ""
     },
     {
       "term": "parlar",
-      "answer": "hablar"
+      "es": "hablar",
+      "en": ""
     },
     {
       "term": "interlingua",
-      "answer": "interlingua (nombre del idioma)"
+      "es": "interlingua (nombre del idioma)",
+      "en": ""
     },
     {
       "term": "con",
-      "answer": "con"
+      "es": "con",
+      "en": ""
     },
     {
       "term": "gratia",
-      "answer": "gracia"
+      "es": "gracia",
+      "en": ""
     },
     {
       "term": "iste",
-      "answer": "este/a"
+      "es": "este/a",
+      "en": ""
     },
     {
       "term": "lingua",
-      "answer": "idioma"
+      "es": "idioma",
+      "en": ""
     },
     {
       "term": "facile",
-      "answer": "fácil"
+      "es": "fácil",
+      "en": ""
     },
     {
       "term": "comprender",
-      "answer": "comprender"
+      "es": "comprender",
+      "en": ""
     },
     {
       "term": "si",
-      "answer": "si (condicional)"
+      "es": "si (condicional)",
+      "en": ""
     },
     {
       "term": "on",
-      "answer": "uno (pronombre impersonal)"
+      "es": "uno (pronombre impersonal)",
+      "en": ""
     },
     {
       "term": "practicar",
-      "answer": "practicar"
+      "es": "practicar",
+      "en": ""
     },
     {
       "term": "cata",
-      "answer": "cada"
+      "es": "cada",
+      "en": ""
     },
     {
       "term": "die",
-      "answer": "día"
+      "es": "día",
+      "en": ""
     },
     {
       "term": "usar",
-      "answer": "usar"
+      "es": "usar",
+      "en": ""
     },
     {
       "term": "curso",
-      "answer": "curso"
+      "es": "curso",
+      "en": ""
     },
     {
       "term": "meliorar",
-      "answer": "mejorar"
+      "es": "mejorar",
+      "en": ""
     },
     {
       "term": "comprension",
-      "answer": "comprensión"
+      "es": "comprensión",
+      "en": ""
     },
     {
       "term": "expression",
-      "answer": "expresión"
+      "es": "expresión",
+      "en": ""
     }
   ],
   "10": [
     {
       "term": "passatempore",
-      "answer": "pasatiempo, hobby"
+      "es": "pasatiempo, hobby",
+      "en": ""
     },
     {
       "term": "principal",
-      "answer": "principal, primordial"
+      "es": "principal, primordial",
+      "en": ""
     },
     {
       "term": "jocar",
-      "answer": "jugar"
+      "es": "jugar",
+      "en": ""
     },
     {
       "term": "football",
-      "answer": "fútbol"
+      "es": "fútbol",
+      "en": ""
     },
     {
       "term": "codificar",
-      "answer": "codificar, programar"
+      "es": "codificar, programar",
+      "en": ""
     },
     {
       "term": "projecto",
-      "answer": "proyecto"
+      "es": "proyecto",
+      "en": ""
     },
     {
       "term": "tempore libere",
-      "answer": "tiempo libre"
+      "es": "tiempo libre",
+      "en": ""
     },
     {
       "term": "amicos",
-      "answer": "amigos"
+      "es": "amigos",
+      "en": ""
     },
     {
       "term": "fin de septimana",
-      "answer": "fin de semana"
+      "es": "fin de semana",
+      "en": ""
     },
     {
       "term": "biber",
-      "answer": "beber (forma “bibe” - yo bebo)"
+      "es": "beber (forma “bibe” - yo bebo)",
+      "en": ""
     },
     {
       "term": "subjecto",
-      "answer": "asunto, tema"
+      "es": "asunto, tema",
+      "en": ""
     },
     {
       "term": "technologia",
-      "answer": "tecnología"
+      "es": "tecnología",
+      "en": ""
     },
     {
       "term": "innovative",
-      "answer": "innovador"
+      "es": "innovador",
+      "en": ""
     },
     {
       "term": "idea",
-      "answer": "idea"
+      "es": "idea",
+      "en": ""
     },
     {
       "term": "Python",
-      "answer": "Python (lenguage de programmation)"
+      "es": "Python (lenguage de programmation)",
+      "en": ""
     },
     {
       "term": "JavaScript",
-      "answer": "JavaScript (lenguage de programmation)"
+      "es": "JavaScript (lenguage de programmation)",
+      "en": ""
     },
     {
       "term": "application web",
-      "answer": "aplicacion web"
+      "es": "aplicacion web",
+      "en": ""
     },
     {
       "term": "automatisation",
-      "answer": "automatización"
+      "es": "automatización",
+      "en": ""
     },
     {
       "term": "facilita",
-      "answer": "facilitar"
+      "es": "facilitar",
+      "en": ""
     },
     {
       "term": "vita quotidian",
-      "answer": "vida cotidiana"
+      "es": "vida cotidiana",
+      "en": ""
     },
     {
       "term": "explorar",
-      "answer": "explorar"
+      "es": "explorar",
+      "en": ""
     },
     {
       "term": "instrumento",
-      "answer": "instrumento"
+      "es": "instrumento",
+      "en": ""
     }
   ],
   "2": [
     {
       "term": "matino",
-      "answer": "mañana"
+      "es": "mañana",
+      "en": ""
     },
     {
       "term": "eveliar se",
-      "answer": "despertarse"
+      "es": "despertarse",
+      "en": ""
     },
     {
       "term": "reguardar",
-      "answer": "mirar, observar"
+      "es": "mirar, observar",
+      "en": ""
     },
     {
       "term": "horologio",
-      "answer": "reloj"
+      "es": "reloj",
+      "en": ""
     },
     {
       "term": "septe",
-      "answer": "siete"
+      "es": "siete",
+      "en": ""
     },
     {
       "term": "poter",
-      "answer": "poder"
+      "es": "poder",
+      "en": ""
     },
     {
       "term": "dormir",
-      "answer": "dormir"
+      "es": "dormir",
+      "en": ""
     },
     {
       "term": "prender",
-      "answer": "tomar, agarrar"
+      "es": "tomar, agarrar",
+      "en": ""
     },
     {
       "term": "leger",
-      "answer": "leer"
+      "es": "leer",
+      "en": ""
     },
     {
       "term": "generes",
-      "answer": "géneros"
+      "es": "géneros",
+      "en": ""
     },
     {
       "term": "rubie",
-      "answer": "rojo"
+      "es": "rojo",
+      "en": ""
     },
     {
       "term": "verde",
-      "answer": "verde"
+      "es": "verde",
+      "en": ""
     },
     {
       "term": "blau",
-      "answer": "azul"
+      "es": "azul",
+      "en": ""
     },
     {
       "term": "jalne",
-      "answer": "amarillo"
+      "es": "amarillo",
+      "en": ""
     },
     {
       "term": "jacer",
-      "answer": "yacer, estar tendido"
+      "es": "yacer, estar tendido",
+      "en": ""
     },
     {
       "term": "lecto",
-      "answer": "cama"
+      "es": "cama",
+      "en": ""
     },
     {
       "term": "audir",
-      "answer": "oír"
+      "es": "oír",
+      "en": ""
     },
     {
       "term": "quando",
-      "answer": "cuando"
+      "es": "cuando",
+      "en": ""
     },
     {
       "term": "seniora",
-      "answer": "señora"
+      "es": "señora",
+      "en": ""
     },
     {
       "term": "aperir",
-      "answer": "abrir"
+      "es": "abrir",
+      "en": ""
     },
     {
       "term": "porta",
-      "answer": "puerta"
+      "es": "puerta",
+      "en": ""
     },
     {
       "term": "matre",
-      "answer": "madre"
+      "es": "madre",
+      "en": ""
     },
     {
       "term": "levar se",
-      "answer": "levantarse"
+      "es": "levantarse",
+      "en": ""
     },
     {
       "term": "vader",
-      "answer": "ir"
+      "es": "ir",
+      "en": ""
     },
     {
       "term": "cocina",
-      "answer": "cocina"
+      "es": "cocina",
+      "en": ""
     }
   ],
   "3": [
     {
       "term": "casa",
-      "answer": "casa"
+      "es": "casa",
+      "en": ""
     },
     {
       "term": "dormitorio",
-      "answer": "dormitorio, habitación"
+      "es": "dormitorio, habitación",
+      "en": ""
     },
     {
       "term": "molle",
-      "answer": "blando"
+      "es": "blando",
+      "en": ""
     },
     {
       "term": "matras",
-      "answer": "colchón"
+      "es": "colchón",
+      "en": ""
     },
     {
       "term": "cossino",
-      "answer": "almohada"
+      "es": "almohada",
+      "en": ""
     },
     {
       "term": "sur",
-      "answer": "sobre, encima de"
+      "es": "sobre, encima de",
+      "en": ""
     },
     {
       "term": "ligno",
-      "answer": "madera"
+      "es": "madera",
+      "en": ""
     },
     {
       "term": "quatro",
-      "answer": "cuatro"
+      "es": "cuatro",
+      "en": ""
     },
     {
       "term": "sedia",
-      "answer": "silla"
+      "es": "silla",
+      "en": ""
     },
     {
       "term": "elegante",
-      "answer": "elegante"
+      "es": "elegante",
+      "en": ""
     },
     {
       "term": "salon",
-      "answer": "sala, salón"
+      "es": "sala, salón",
+      "en": ""
     },
     {
       "term": "luminose",
-      "answer": "luminoso"
+      "es": "luminoso",
+      "en": ""
     },
     {
       "term": "continer",
-      "answer": "contener"
+      "es": "contener",
+      "en": ""
     },
     {
       "term": "sofa",
-      "answer": "sofá"
+      "es": "sofá",
+      "en": ""
     },
     {
       "term": "television",
-      "answer": "televisión"
+      "es": "televisión",
+      "en": ""
     },
     {
       "term": "catto",
-      "answer": "gato"
+      "es": "gato",
+      "en": ""
     },
     {
       "term": "sub",
-      "answer": "debajo de"
+      "es": "debajo de",
+      "en": ""
     },
     {
       "term": "durante",
-      "answer": "durante"
+      "es": "durante",
+      "en": ""
     },
     {
       "term": "vespere",
-      "answer": "tarde, anochecer"
+      "es": "tarde, anochecer",
+      "en": ""
     },
     {
       "term": "invitar",
-      "answer": "invitar"
+      "es": "invitar",
+      "en": ""
     },
     {
       "term": "amico",
-      "answer": "amigo"
+      "es": "amigo",
+      "en": ""
     },
     {
       "term": "parve",
-      "answer": "pequeño"
+      "es": "pequeño",
+      "en": ""
     },
     {
       "term": "reunion",
-      "answer": "reunión"
+      "es": "reunión",
+      "en": ""
     },
     {
       "term": "cata",
-      "answer": "cada (repetido del texto previe, incluse pro completar)"
+      "es": "cada (repetido del texto previe, incluse pro completar)",
+      "en": ""
     },
     {
       "term": "sabbato",
-      "answer": "sábado"
+      "es": "sábado",
+      "en": ""
     }
   ],
   "4": [
     {
       "term": "levar se",
-      "answer": "levantarse"
+      "es": "levantarse",
+      "en": ""
     },
     {
       "term": "septe",
-      "answer": "siete"
+      "es": "siete",
+      "en": ""
     },
     {
       "term": "vestir se",
-      "answer": "vestirse"
+      "es": "vestirse",
+      "en": ""
     },
     {
       "term": "rapidemente",
-      "answer": "rápidamente"
+      "es": "rápidamente",
+      "en": ""
     },
     {
       "term": "camisa",
-      "answer": "camisa"
+      "es": "camisa",
+      "en": ""
     },
     {
       "term": "pantalones",
-      "answer": "pantalones"
+      "es": "pantalones",
+      "en": ""
     },
     {
       "term": "confortabile",
-      "answer": "cómodo"
+      "es": "cómodo",
+      "en": ""
     },
     {
       "term": "mangiar",
-      "answer": "comer"
+      "es": "comer",
+      "en": ""
     },
     {
       "term": "pan",
-      "answer": "pan"
+      "es": "pan",
+      "en": ""
     },
     {
       "term": "lacte",
-      "answer": "leche"
+      "es": "leche",
+      "en": ""
     },
     {
       "term": "parve",
-      "answer": "pequeño"
+      "es": "pequeño",
+      "en": ""
     },
     {
       "term": "fructo",
-      "answer": "fruta"
+      "es": "fruta",
+      "en": ""
     },
     {
       "term": "jentaculo",
-      "answer": "desayuno"
+      "es": "desayuno",
+      "en": ""
     },
     {
       "term": "octo",
-      "answer": "ocho"
+      "es": "ocho",
+      "en": ""
     },
     {
       "term": "officio",
-      "answer": "oficina"
+      "es": "oficina",
+      "en": ""
     },
     {
       "term": "autobus",
-      "answer": "colectivo, autobús"
+      "es": "colectivo, autobús",
+      "en": ""
     },
     {
       "term": "arrivar",
-      "answer": "llegar"
+      "es": "llegar",
+      "en": ""
     },
     {
       "term": "medie",
-      "answer": "y media (hora)"
+      "es": "y media (hora)",
+      "en": ""
     },
     {
       "term": "labor",
-      "answer": "trabajo"
+      "es": "trabajo",
+      "en": ""
     },
     {
       "term": "comenciar",
-      "answer": "comenzar"
+      "es": "comenzar",
+      "en": ""
     },
     {
       "term": "scriber",
-      "answer": "escribir"
+      "es": "escribir",
+      "en": ""
     },
     {
       "term": "reporto",
-      "answer": "informe, reporte"
+      "es": "informe, reporte",
+      "en": ""
     },
     {
       "term": "responder",
-      "answer": "responder"
+      "es": "responder",
+      "en": ""
     },
     {
       "term": "e-mail",
-      "answer": "correo electrónico"
+      "es": "correo electrónico",
+      "en": ""
     },
     {
       "term": "diligentia",
-      "answer": "diligencia, esmero"
+      "es": "diligencia, esmero",
+      "en": ""
     },
     {
       "term": "practicar",
-      "answer": "practicar"
+      "es": "practicar",
+      "en": ""
     },
     {
       "term": "yoga",
-      "answer": "yoga"
+      "es": "yoga",
+      "en": ""
     },
     {
       "term": "studio",
-      "answer": "estudio, sala"
+      "es": "estudio, sala",
+      "en": ""
     },
     {
       "term": "pois",
-      "answer": "luego, después"
+      "es": "luego, después",
+      "en": ""
     },
     {
       "term": "pro",
-      "answer": "para"
+      "es": "para",
+      "en": ""
     },
     {
       "term": "durante",
-      "answer": "durante"
+      "es": "durante",
+      "en": ""
     }
   ],
   "5": [
     {
       "term": "pizza",
-      "answer": "pizza"
+      "es": "pizza",
+      "en": ""
     },
     {
       "term": "caseo",
-      "answer": "queso"
+      "es": "queso",
+      "en": ""
     },
     {
       "term": "tomate",
-      "answer": "tomate"
+      "es": "tomate",
+      "en": ""
     },
     {
       "term": "parve",
-      "answer": "pequeño"
+      "es": "pequeño",
+      "en": ""
     },
     {
       "term": "pizzeria",
-      "answer": "pizzería"
+      "es": "pizzería",
+      "en": ""
     },
     {
       "term": "local",
-      "answer": "local"
+      "es": "local",
+      "en": ""
     },
     {
       "term": "menu",
-      "answer": "menú"
+      "es": "menú",
+      "en": ""
     },
     {
       "term": "offerer",
-      "answer": "ofrecer"
+      "es": "ofrecer",
+      "en": ""
     },
     {
       "term": "diverse",
-      "answer": "diversos/as"
+      "es": "diversos/as",
+      "en": ""
     },
     {
       "term": "specialitate",
-      "answer": "especialidad"
+      "es": "especialidad",
+      "en": ""
     },
     {
       "term": "pasta",
-      "answer": "pasta"
+      "es": "pasta",
+      "en": ""
     },
     {
       "term": "pesto",
-      "answer": "pesto"
+      "es": "pesto",
+      "en": ""
     },
     {
       "term": "gelato",
-      "answer": "helado"
+      "es": "helado",
+      "en": ""
     },
     {
       "term": "artisanal",
-      "answer": "artesanal"
+      "es": "artesanal",
+      "en": ""
     },
     {
       "term": "fin",
-      "answer": "fin"
+      "es": "fin",
+      "en": ""
     },
     {
       "term": "prandio",
-      "answer": "almuerzo, comida"
+      "es": "almuerzo, comida",
+      "en": ""
     },
     {
       "term": "biber",
-      "answer": "beber"
+      "es": "beber",
+      "en": ""
     },
     {
       "term": "sovente",
-      "answer": "a menudo"
+      "es": "a menudo",
+      "en": ""
     },
     {
       "term": "caffe",
-      "answer": "café"
+      "es": "café",
+      "en": ""
     },
     {
       "term": "calide",
-      "answer": "caliente"
+      "es": "caliente",
+      "en": ""
     },
     {
       "term": "cena",
-      "answer": "cena"
+      "es": "cena",
+      "en": ""
     },
     {
       "term": "vices",
-      "answer": "veces"
+      "es": "veces",
+      "en": ""
     },
     {
       "term": "prefere",
-      "answer": "preferir"
+      "es": "preferir",
+      "en": ""
     },
     {
       "term": "aqua",
-      "answer": "agua"
+      "es": "agua",
+      "en": ""
     },
     {
       "term": "frigide",
-      "answer": "fría"
+      "es": "fría",
+      "en": ""
     },
     {
       "term": "refrigerator",
-      "answer": "heladera, refrigerador"
+      "es": "heladera, refrigerador",
+      "en": ""
     },
     {
       "term": "clar",
-      "answer": "clara"
+      "es": "clara",
+      "en": ""
     },
     {
       "term": "restaurante",
-      "answer": "restaurante"
+      "es": "restaurante",
+      "en": ""
     },
     {
       "term": "venerdi",
-      "answer": "viernes"
+      "es": "viernes",
+      "en": ""
     },
     {
       "term": "gauder de",
-      "answer": "disfrutar"
+      "es": "disfrutar",
+      "en": ""
     },
     {
       "term": "ambiente",
-      "answer": "ambiente"
+      "es": "ambiente",
+      "en": ""
     },
     {
       "term": "amical",
-      "answer": "amistoso"
+      "es": "amistoso",
+      "en": ""
     },
     {
       "term": "gastronomia",
-      "answer": "gastronomía"
+      "es": "gastronomía",
+      "en": ""
     },
     {
       "term": "excellente",
-      "answer": "excelente"
+      "es": "excelente",
+      "en": ""
     }
   ],
   "6": [
     {
       "term": "Buenos Aires",
-      "answer": "Buenos Aires"
+      "es": "Buenos Aires",
+      "en": ""
     },
     {
       "term": "citate",
-      "answer": "ciudad"
+      "es": "ciudad",
+      "en": ""
     },
     {
       "term": "quartiero",
-      "answer": "barrio, vecindario"
+      "es": "barrio, vecindario",
+      "en": ""
     },
     {
       "term": "character",
-      "answer": "caracter, personalidad"
+      "es": "caracter, personalidad",
+      "en": ""
     },
     {
       "term": "vibrante",
-      "answer": "vibrante"
+      "es": "vibrante",
+      "en": ""
     },
     {
       "term": "museo",
-      "answer": "museo"
+      "es": "museo",
+      "en": ""
     },
     {
       "term": "famose",
-      "answer": "famoso"
+      "es": "famoso",
+      "en": ""
     },
     {
       "term": "National",
-      "answer": "Nacional"
+      "es": "Nacional",
+      "en": ""
     },
     {
       "term": "historic",
-      "answer": "historicas"
+      "es": "historicas",
+      "en": ""
     },
     {
       "term": "se trova",
-      "answer": "se encuentra"
+      "es": "se encuentra",
+      "en": ""
     },
     {
       "term": "symbolo",
-      "answer": "simbolo"
+      "es": "simbolo",
+      "en": ""
     },
     {
       "term": "transporto",
-      "answer": "transporte"
+      "es": "transporte",
+      "en": ""
     },
     {
       "term": "public",
-      "answer": "publico"
+      "es": "publico",
+      "en": ""
     },
     {
       "term": "comprender",
-      "answer": "comprender, incluir"
+      "es": "comprender, incluir",
+      "en": ""
     },
     {
       "term": "traino",
-      "answer": "tren"
+      "es": "tren",
+      "en": ""
     },
     {
       "term": "rapide",
-      "answer": "rapido"
+      "es": "rapido",
+      "en": ""
     },
     {
       "term": "connecte",
-      "answer": "conecta"
+      "es": "conecta",
+      "en": ""
     },
     {
       "term": "stratas",
-      "answer": "calles"
+      "es": "calles",
+      "en": ""
     },
     {
       "term": "animate",
-      "answer": "animado"
+      "es": "animado",
+      "en": ""
     },
     {
       "term": "tourista",
-      "answer": "turista"
+      "es": "turista",
+      "en": ""
     },
     {
       "term": "Obelisco",
-      "answer": "Obelisco (monumento)"
+      "es": "Obelisco (monumento)",
+      "en": ""
     },
     {
       "term": "libreria",
-      "answer": "libreria"
+      "es": "libreria",
+      "en": ""
     },
     {
       "term": "artisanal",
-      "answer": "artesanal"
+      "es": "artesanal",
+      "en": ""
     }
   ],
   "7": [
     {
       "term": "climate",
-      "answer": "clima"
+      "es": "clima",
+      "en": ""
     },
     {
       "term": "anno",
-      "answer": "año"
+      "es": "año",
+      "en": ""
     },
     {
       "term": "estate",
-      "answer": "verano"
+      "es": "verano",
+      "en": ""
     },
     {
       "term": "grado",
-      "answer": "grado"
+      "es": "grado",
+      "en": ""
     },
     {
       "term": "dies",
-      "answer": "días"
+      "es": "días",
+      "en": ""
     },
     {
       "term": "insolate",
-      "answer": "soleado"
+      "es": "soleado",
+      "en": ""
     },
     {
       "term": "ideal",
-      "answer": "ideal"
+      "es": "ideal",
+      "en": ""
     },
     {
       "term": "promenar",
-      "answer": "pasear"
+      "es": "pasear",
+      "en": ""
     },
     {
       "term": "parco",
-      "answer": "parque"
+      "es": "parque",
+      "en": ""
     },
     {
       "term": "hiberno",
-      "answer": "invierno"
+      "es": "invierno",
+      "en": ""
     },
     {
       "term": "minus",
-      "answer": "menos"
+      "es": "menos",
+      "en": ""
     },
     {
       "term": "pluvia",
-      "answer": "lluvia"
+      "es": "lluvia",
+      "en": ""
     },
     {
       "term": "frequente",
-      "answer": "frecuente"
+      "es": "frecuente",
+      "en": ""
     },
     {
       "term": "vento",
-      "answer": "viento"
+      "es": "viento",
+      "en": ""
     },
     {
       "term": "frigide",
-      "answer": "frío"
+      "es": "frío",
+      "en": ""
     },
     {
       "term": "intense",
-      "answer": "intenso"
+      "es": "intenso",
+      "en": ""
     },
     {
       "term": "celo",
-      "answer": "cielo"
+      "es": "cielo",
+      "en": ""
     },
     {
       "term": "clar",
-      "answer": "claro"
+      "es": "claro",
+      "en": ""
     },
     {
       "term": "suave",
-      "answer": "suave"
+      "es": "suave",
+      "en": ""
     },
     {
       "term": "vices",
-      "answer": "veces"
+      "es": "veces",
+      "en": ""
     },
     {
       "term": "tempesta",
-      "answer": "tormenta"
+      "es": "tormenta",
+      "en": ""
     },
     {
       "term": "rapidemente",
-      "answer": "rápidamente"
+      "es": "rápidamente",
+      "en": ""
     },
     {
       "term": "forte",
-      "answer": "fuerte"
+      "es": "fuerte",
+      "en": ""
     },
     {
       "term": "temperatura",
-      "answer": "temperatura"
+      "es": "temperatura",
+      "en": ""
     },
     {
       "term": "variar",
-      "answer": "variar"
+      "es": "variar",
+      "en": ""
     },
     {
       "term": "bastante",
-      "answer": "bastante"
+      "es": "bastante",
+      "en": ""
     },
     {
       "term": "requirer",
-      "answer": "requerir"
+      "es": "requerir",
+      "en": ""
     },
     {
       "term": "preparar",
-      "answer": "preparar"
+      "es": "preparar",
+      "en": ""
     },
     {
       "term": "vestimento",
-      "answer": "vestimenta, ropa"
+      "es": "vestimenta, ropa",
+      "en": ""
     },
     {
       "term": "situation",
-      "answer": "situación"
+      "es": "situación",
+      "en": ""
     }
   ],
   "8": [
     {
       "term": "comprar",
-      "answer": "comprar"
+      "es": "comprar",
+      "en": ""
     },
     {
       "term": "grammatica",
-      "answer": "gramatica"
+      "es": "gramatica",
+      "en": ""
     },
     {
       "term": "presentation",
-      "answer": "presentacion"
+      "es": "presentacion",
+      "en": ""
     },
     {
       "term": "precio",
-      "answer": "precio, costo"
+      "es": "precio, costo",
+      "en": ""
     },
     {
       "term": "euro",
-      "answer": "euro"
+      "es": "euro",
+      "en": ""
     },
     {
       "term": "systema",
-      "answer": "sistema"
+      "es": "sistema",
+      "en": ""
     },
     {
       "term": "digital",
-      "answer": "digital"
+      "es": "digital",
+      "en": ""
     },
     {
       "term": "mandar",
-      "answer": "enviar"
+      "es": "enviar",
+      "en": ""
     },
     {
       "term": "recepta",
-      "answer": "recibo"
+      "es": "recibo",
+      "en": ""
     },
     {
       "term": "cliente",
-      "answer": "cliente"
+      "es": "cliente",
+      "en": ""
     },
     {
       "term": "beneficiar se",
-      "answer": "beneficiarse"
+      "es": "beneficiarse",
+      "en": ""
     },
     {
       "term": "disconto",
-      "answer": "descuento"
+      "es": "descuento",
+      "en": ""
     },
     {
       "term": "per cento",
-      "answer": "por ciento"
+      "es": "por ciento",
+      "en": ""
     },
     {
       "term": "fidel",
-      "answer": "fiel"
+      "es": "fiel",
+      "en": ""
     },
     {
       "term": "pagar",
-      "answer": "pagar"
+      "es": "pagar",
+      "en": ""
     },
     {
       "term": "carta de credito",
-      "answer": "tarjeta de credito"
+      "es": "tarjeta de credito",
+      "en": ""
     },
     {
       "term": "conservar",
-      "answer": "conservar"
+      "es": "conservar",
+      "en": ""
     },
     {
       "term": "futur",
-      "answer": "futuro/a"
+      "es": "futuro/a",
+      "en": ""
     },
     {
       "term": "referentia",
-      "answer": "referencia"
+      "es": "referencia",
+      "en": ""
     }
   ],
   "9": [
     {
       "term": "vader",
-      "answer": "ir"
+      "es": "ir",
+      "en": ""
     },
     {
       "term": "traino",
-      "answer": "tren"
+      "es": "tren",
+      "en": ""
     },
     {
       "term": "proxime",
-      "answer": "próximo"
+      "es": "próximo",
+      "en": ""
     },
     {
       "term": "venerdi",
-      "answer": "viernes"
+      "es": "viernes",
+      "en": ""
     },
     {
       "term": "trajecto",
-      "answer": "trayecto, recorrido"
+      "es": "trayecto, recorrido",
+      "en": ""
     },
     {
       "term": "circa",
-      "answer": "aproximadamente"
+      "es": "aproximadamente",
+      "en": ""
     },
     {
       "term": "paisage",
-      "answer": "paisaje"
+      "es": "paisaje",
+      "en": ""
     },
     {
       "term": "montaniose",
-      "answer": "montañoso"
+      "es": "montañoso",
+      "en": ""
     },
     {
       "term": "campo",
-      "answer": "campo"
+      "es": "campo",
+      "en": ""
     },
     {
       "term": "sede",
-      "answer": "asiento"
+      "es": "asiento",
+      "en": ""
     },
     {
       "term": "sito web",
-      "answer": "sitio web"
+      "es": "sitio web",
+      "en": ""
     },
     {
       "term": "official",
-      "answer": "oficial"
+      "es": "oficial",
+      "en": ""
     },
     {
       "term": "compania",
-      "answer": "compañía"
+      "es": "compañía",
+      "en": ""
     },
     {
       "term": "ferroviari",
-      "answer": "ferroviario/a"
+      "es": "ferroviario/a",
+      "en": ""
     },
     {
       "term": "station",
-      "answer": "estación"
+      "es": "estación",
+      "en": ""
     },
     {
       "term": "organisar",
-      "answer": "organizar"
+      "es": "organizar",
+      "en": ""
     },
     {
       "term": "cafe",
-      "answer": "café"
+      "es": "café",
+      "en": ""
     },
     {
       "term": "boteca",
-      "answer": "tienda, negocio"
+      "es": "tienda, negocio",
+      "en": ""
     },
     {
       "term": "information",
-      "answer": "información"
+      "es": "información",
+      "en": ""
     },
     {
       "term": "passagero",
-      "answer": "pasajero"
+      "es": "pasajero",
+      "en": ""
     },
     {
       "term": "viage",
-      "answer": "viaje"
+      "es": "viaje",
+      "en": ""
     },
     {
       "term": "leger",
-      "answer": "leer"
+      "es": "leer",
+      "en": ""
     },
     {
       "term": "musica",
-      "answer": "música"
+      "es": "música",
+      "en": ""
     },
     {
       "term": "passar",
-      "answer": "pasar"
+      "es": "pasar",
+      "en": ""
     },
     {
       "term": "tempore",
-      "answer": "tiempo"
+      "es": "tiempo",
+      "en": ""
     }
-  ]
+  ],
+  "extras": []
 }

--- a/public/index.html
+++ b/public/index.html
@@ -72,8 +72,5 @@
       }
     });
   </script>
-    <!-- Footer externo -->
-  <footer></footer>
-  <script src="js/include.js"></script>
 </body>
 </html>

--- a/public/js/exercises.js
+++ b/public/js/exercises.js
@@ -5,22 +5,25 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const data = await fetch('/data/vocab.json').then(r => r.json());
   const items = data[lesson] || [];
+  const lang = localStorage.getItem('lang') || 'es';
 
   const template = await fetch('/components/exercise.html').then(r => r.text());
   container.innerHTML = template;
 
   const form = container.querySelector('#exercise-form');
-  items.forEach(({ term, answer }) => {
-    const item = document.createElement('div');
-    item.className = 'exercise-item';
-    item.innerHTML = `
+  items.forEach(vocab => {
+    const answer = vocab[lang] || vocab.es;
+    const term = vocab.term;
+    const element = document.createElement('div');
+    element.className = 'exercise-item';
+    element.innerHTML = `
       <label class="term">${term}:</label>
       <div class="answer">
         <input type="text" data-answer="${answer}" class="exercise-input">
         <span class="feedback-icon"></span>
       </div>
     `;
-    form.appendChild(item);
+    form.appendChild(element);
   });
 
   const btnCheck = container.querySelector('.btn-comprobar');

--- a/public/js/include.js
+++ b/public/js/include.js
@@ -6,14 +6,27 @@ document.addEventListener("DOMContentLoaded", function () {
     ? "../components/"
     : "components/";
 
-  function include(selector, file) {
+  function include(selector, file, cb) {
     fetch(base + file)
       .then(res => res.text())
       .then(html => {
         document.querySelector(selector).innerHTML = html;
+        if (cb) cb();
       });
   }
 
-  include("nav", "navbar.html");
+  function initLang() {
+    const current = localStorage.getItem('lang') || 'es';
+    document.querySelectorAll('.lang-option').forEach(link => {
+      if (link.dataset.lang === current) link.classList.add('active');
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        localStorage.setItem('lang', link.dataset.lang);
+        location.reload();
+      });
+    });
+  }
+
+  include("nav", "navbar.html", initLang);
   include("footer", "footer.html");
 });

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -1,6 +1,7 @@
 // Agrega tooltips de traducción a todos los textos de las lecciones
 
 document.addEventListener('DOMContentLoaded', () => {
+  const lang = localStorage.getItem('lang') || 'es';
   // Cargar vocabulario
   fetch('/data/vocab.json')
     .then(res => res.json())
@@ -8,9 +9,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const vocab = {};
       // Unir todas las lecciones en un solo objeto de búsqueda
       Object.values(data).forEach(arr => {
-        arr.forEach(({ term, answer }) => {
-          vocab[term.toLowerCase()] = answer;
-        });
+        if (Array.isArray(arr)) {
+          arr.forEach(item => {
+            const translation = item[lang] || item.es;
+            vocab[item.term.toLowerCase()] = translation;
+          });
+        }
       });
 
       const paragraphs = document.querySelectorAll('.text-block p');

--- a/public/js/vocab-table.js
+++ b/public/js/vocab-table.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const table = document.querySelector('.vocab-table');
+  if (!table) return;
+  const tbody = table.querySelector('tbody');
+  if (!tbody) return;
+  const lesson = document.getElementById('exercise-container');
+  const lessonId = lesson ? lesson.dataset.lesson : null;
+  if (!lessonId) return;
+  const data = await fetch('/data/vocab.json').then(r => r.json());
+  const items = data[lessonId] || [];
+  const lang = localStorage.getItem('lang') || 'es';
+  items.forEach(item => {
+    const tr = document.createElement('tr');
+    const tdTerm = document.createElement('td');
+    tdTerm.textContent = item.term;
+    const tdTrans = document.createElement('td');
+    tdTrans.textContent = item[lang] || item.es;
+    tr.appendChild(tdTerm);
+    tr.appendChild(tdTrans);
+    tbody.appendChild(tr);
+  });
+  const btn = document.createElement('button');
+  btn.innerHTML = '<i class="fa-solid fa-book-open"></i> Mostrar vocabulario';
+  btn.className = 'vocab-toggle';
+  table.before(btn);
+  table.style.display = 'none';
+  btn.addEventListener('click', () => {
+    const visible = table.style.display !== 'none';
+    table.style.display = visible ? 'none' : 'block';
+    btn.innerHTML = visible
+      ? '<i class="fa-solid fa-book-open"></i> Mostrar vocabulario'
+      : '<i class="fa-solid fa-eye-slash"></i> Ocultar vocabulario';
+  });
+});

--- a/public/lection/lection1.html
+++ b/public/lection/lection1.html
@@ -41,45 +41,7 @@
         <thead>
           <tr><th colspan="3">Vocabulario</th></tr>
         </thead>
-        <tbody>
-          <tr>
-            <td>
-              <ul>
-                <li><strong>io</strong>: yo</li>
-                <li><strong>esser</strong>: ser / estar</li>
-                <li><strong>habitar</strong>: habitar, vivir</li>
-                <li><strong>appartamento</strong>: departamento, apartamento</li>
-                <li><strong>tu</strong>: tú</li>
-                <li><strong>es</strong>: eres / estás (forma del verbo "esser")</li>
-                <li><strong>illa</strong>: ella</li>
-                <li><strong>amica</strong>: amiga</li>
-                <li><strong>nos</strong>: nosotros/as</li>
-                <li><strong>parlar</strong>: hablar</li>
-                <li><strong>interlingua</strong>: interlingua (nombre del idioma)</li>
-                <li><strong>con</strong>: con</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li><strong>gratia</strong>: gracia</li>
-                <li><strong>iste</strong>: este/a</li>
-                <li><strong>lingua</strong>: idioma</li>
-                <li><strong>facile</strong>: fácil</li>
-                <li><strong>comprender</strong>: comprender</li>
-                <li><strong>si</strong>: si (condicional)</li>
-                <li><strong>on</strong>: uno (pronombre impersonal)</li>
-                <li><strong>practicar</strong>: practicar</li>
-                <li><strong>cata</strong>: cada</li>
-                <li><strong>die</strong>: día</li>
-                <li><strong>usar</strong>: usar</li>
-                <li><strong>curso</strong>: curso</li>
-                <li><strong>meliorar</strong>: mejorar</li>
-                <li><strong>comprension</strong>: comprensión</li>
-                <li><strong>expression</strong>: expresión</li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
+        <tbody></tbody>
       </table>
     </div>
 
@@ -107,6 +69,7 @@
       <div id="exercise-container" data-lesson="1"></div>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
   </main>
   <!-- Footer externo -->
   <footer></footer>


### PR DESCRIPTION
## Summary
- fix duplicate markup in contos.html and index.html
- add dropdown in navbar for language selection
- load navbar/footer with language init hook
- refactor exercises and tooltip scripts to read selected language
- add dynamic vocabulary table script
- start expanding `vocab.json` with `es`/`en` fields
- wire first lesson to new vocab table
- style the vocabulary table toggle button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b9d9d2a74832c9285f00b91cd29d5