### PR TITLE
Add dynamic lesson grid

### DIFF
--- a/public/components/navbar.html
+++ b/public/components/navbar.html
@@ -6,21 +6,6 @@
     </a>
     <ul class="nav-links">
       <li class="dropdown">
-        <a href="#">Lectiones ▼</a>
-        <ul class="dropdown-menu">
-          <li><a href="/lection/lection1.html">Lection 1</a></li>
-          <li><a href="/lection/lection2.html">Lection 2</a></li>
-          <li><a href="/lection/lection3.html">Lection 3</a></li>
-          <li><a href="/lection/lection4.html">Lection 4</a></li>
-          <li><a href="/lection/lection5.html">Lection 5</a></li>
-          <li><a href="/lection/lection6.html">Lection 6</a></li>
-          <li><a href="/lection/lection7.html">Lection 7</a></li>
-          <li><a href="/lection/lection8.html">Lection 8</a></li>
-          <li><a href="/lection/lection9.html">Lection 9</a></li>
-          <li><a href="/lection/lection10.html">Lection 10</a></li>
-        </ul>
-      </li>
-      <li class="dropdown">
         <a href="#">Appendice ▼</a>
         <ul class="dropdown-menu">
           <li><a href="/appendice/grammatica.html">Breve grammatica</a></li>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -359,7 +359,42 @@ main {
     width: 100%;
     gap: 0.5rem;
   }
-  .dropdown-menu {
-    position: static;
+.dropdown-menu {
+  position: static;
   }
+}
+
+/* Home lessons grid */
+.lesson-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 20px;
+  justify-items: center;
+  margin: 24px auto;
+  max-width: 980px;
+}
+
+.lesson-circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: var(--primary-color);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  text-align: center;
+  padding: 8px;
+  transition: transform 0.2s;
+}
+
+.lesson-circle:hover {
+  transform: scale(1.06);
+}
+
+.lesson-circle i {
+  font-size: 2rem;
+  margin-bottom: 4px;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,8 @@
       </p>
     </section>
 
+    <section id="home-lessons" class="lesson-grid"></section>
+
     <!-- Sección Appendice -->
     <section id="appendix-section" class="card" style="display:none;">
       <h2>Appendice</h2>
@@ -43,6 +45,7 @@
   <!-- Scripts -->
   <script src="js/include.js"></script>
   <script src="js/tooltip.js"></script>
+  <script src="js/main.js"></script>
   <script>
     // Navegación interna para Home y Appendice
     document.addEventListener("DOMContentLoaded", () => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,55 @@
+async function loadLessons(){
+  const data = await fetch('/public/data/vocab.json').then(r=>r.json());
+  const container = document.getElementById('home-lessons');
+
+  const iconMap = {
+    "basico1":"fas fa-lightbulb",
+    "basico2":"fas fa-lightbulb",
+    "phrases-quotidian":"fas fa-comment-dots",
+    "alimentos":"fas fa-apple-alt",
+    "animales":"fas fa-dog",
+    "adjectivos1":"fas fa-adjust",
+    "plurales":"fas fa-clone",
+    "esser-haber":"fas fa-user-check",
+    "vestimentos":"fas fa-tshirt",
+    "adjectivos-possessive":"fas fa-hand-holding-heart",
+    "colores":"fas fa-palette",
+    "presente1":"fas fa-clock",
+    "demonstrativos1":"fas fa-arrows-alt-h",
+    "conjunctiones":"fas fa-link",
+    "questiones":"fas fa-question",
+    "verbos2":"fas fa-running",
+    "adjectivos2":"fas fa-star-half-alt",
+    "prepositiones":"fas fa-map-signs",
+    "numeros":"fas fa-sort-numeric-up",
+    "familia":"fas fa-users",
+    "possessives2":"fas fa-handshake",
+    "verbos3":"fas fa-swimmer",
+    "datas-tempore":"fas fa-calendar-alt",
+    "verbos4":"fas fa-plane",
+    "adverbios1":"fas fa-angle-double-right",
+    "verbos5":"fas fa-music",
+    "adverbios2":"fas fa-bolt",
+    "occupationes":"fas fa-briefcase",
+    "verbos6":"fas fa-rocket",
+    "negativos":"fas fa-minus-circle",
+    "adverbios3":"fas fa-forward",
+    "prender-casa":"fas fa-home",
+    "technologia":"fas fa-microchip"
+  };
+
+  Object.keys(data).forEach(slug=>{
+    const a=document.createElement('a');
+    a.href=`/lesson.html?slug=${slug}`;
+    a.className='lesson-circle';
+    const iconClass=iconMap[slug]||'fas fa-book';
+    a.innerHTML=`<i class="${iconClass}"></i><span>${displayName(slug)}</span>`;
+    container.appendChild(a);
+  });
+}
+
+function displayName(slug){
+  return slug.replace(/-/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
+}
+
+document.addEventListener('DOMContentLoaded',loadLessons);

--- a/public/lesson.html
+++ b/public/lesson.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Schola Interlingua - Lection</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <div class="card">
+      <h2 id="lesson-title"></h2>
+      <div class="vocab-table">
+        <table>
+          <thead>
+            <tr><th colspan="3">Vocabulario</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div id="exercise-container"></div>
+    </div>
+  </main>
+  <footer></footer>
+
+  <script src="js/include.js"></script>
+  <script src="js/tooltip.js"></script>
+  <script src="js/exercises.js"></script>
+  <script src="js/vocab-table.js"></script>
+  <script>
+    const slug = new URLSearchParams(location.search).get('slug') || '';
+    document.getElementById('exercise-container').dataset.lesson = slug;
+    document.getElementById('lesson-title').textContent = displayName(slug);
+    function displayName(str){
+      return str.replace(/-/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add grid of lesson icons to the home page
- remove static lesson links from the navbar
- style lesson circles and grid layout
- generate lesson links dynamically with main.js
- create reusable `lesson.html` to display each lesson

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d0db07764832caafbd41f4de7e741