### PR TITLE
Add course lessons and navigation

### DIFF
--- a/public/appendice/contos.html
+++ b/public/appendice/contos.html
@@ -39,5 +39,6 @@
   <footer></footer>
   <script src="/js/tooltip.js"></script>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/appendice/grammatica.html
+++ b/public/appendice/grammatica.html
@@ -177,5 +177,6 @@
   <footer></footer>
   <script src="/js/tooltip.js"></script>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/appendice/numeros.html
+++ b/public/appendice/numeros.html
@@ -91,6 +91,7 @@
   <footer></footer>
   <script src="/js/tooltip.js"></script>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>
 k

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,7 @@
 
   <!-- Scripts -->
   <script src="js/include.js"></script>
+  <script src="js/nav.js"></script>
   <script src="js/tooltip.js"></script>
   <script>
     // Navegación interna para Home y Appendice

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -1,0 +1,78 @@
+const cursoSlugs = [
+  "basico1","basico2","phrases-quotidian","alimentos","animales",
+  "adjectivos1","plurales","esser-haber","vestimentos",
+  "adjectivos-possessive","colores","presente1","demonstrativos1",
+  "conjunctiones","questiones","verbos2","adjectivos2",
+  "prepositiones","numeros","familia","possessives2","verbos3",
+  "datas-tempore","verbos4","adverbios1","verbos5","adverbios2",
+  "occupationes","verbos6","negativos","adverbios3",
+  "prender-casa","technologia"
+];
+
+const iconMap = {
+  basico1: 'fas fa-lightbulb',
+  basico2: 'fas fa-lightbulb',
+  'phrases-quotidian': 'fas fa-comment-dots',
+  alimentos: 'fas fa-apple-alt',
+  animales: 'fas fa-dog',
+  adjectivos1: 'fas fa-font',
+  plurales: 'fas fa-clone',
+  'esser-haber': 'fas fa-check-double',
+  vestimentos: 'fas fa-tshirt',
+  'adjectivos-possessive': 'fas fa-hand-holding-heart',
+  colores: 'fas fa-palette',
+  presente1: 'fas fa-clock',
+  demonstrativos1: 'fas fa-hand-point-up',
+  conjunctiones: 'fas fa-link',
+  questiones: 'fas fa-question-circle',
+  verbos2: 'fas fa-running',
+  adjectivos2: 'fas fa-font',
+  prepositiones: 'fas fa-map-signs',
+  numeros: 'fas fa-sort-numeric-up',
+  familia: 'fas fa-users',
+  possessives2: 'fas fa-hand-holding-heart',
+  verbos3: 'fas fa-running',
+  'datas-tempore': 'fas fa-calendar-alt',
+  verbos4: 'fas fa-running',
+  adverbios1: 'fas fa-rocket',
+  verbos5: 'fas fa-running',
+  adverbios2: 'fas fa-rocket',
+  occupationes: 'fas fa-briefcase',
+  verbos6: 'fas fa-running',
+  negativos: 'fas fa-ban',
+  adverbios3: 'fas fa-rocket',
+  'prender-casa': 'fas fa-home',
+  technologia: 'fas fa-microchip'
+};
+
+function toTitle(str) {
+  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ');
+}
+
+function buildCursoMenu() {
+  const navLinks = document.querySelector('.nav-links');
+  if (!navLinks) return;
+  const li = document.createElement('li');
+  li.className = 'dropdown';
+  li.innerHTML = '<a href="#">Curso ▼</a><ul class="dropdown-menu"></ul>';
+  const menu = li.querySelector('.dropdown-menu');
+  cursoSlugs.forEach(slug => {
+    const icon = iconMap[slug] || 'fas fa-book';
+    const a = document.createElement('a');
+    a.href = `/lessons/${slug}.html`;
+    a.innerHTML = `<i class="${icon}"></i> ${toTitle(slug)}`;
+    const item = document.createElement('li');
+    item.appendChild(a);
+    menu.appendChild(item);
+  });
+  navLinks.appendChild(li);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const timer = setInterval(() => {
+    if (document.querySelector('.nav-links')) {
+      clearInterval(timer);
+      buildCursoMenu();
+    }
+  }, 50);
+});

--- a/public/lection/lection1.html
+++ b/public/lection/lection1.html
@@ -65,5 +65,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection10.html
+++ b/public/lection/lection10.html
@@ -62,5 +62,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection2.html
+++ b/public/lection/lection2.html
@@ -60,5 +60,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection3.html
+++ b/public/lection/lection3.html
@@ -51,5 +51,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection4.html
+++ b/public/lection/lection4.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection5.html
+++ b/public/lection/lection5.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection6.html
+++ b/public/lection/lection6.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection7.html
+++ b/public/lection/lection7.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection8.html
+++ b/public/lection/lection8.html
@@ -62,5 +62,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection9.html
+++ b/public/lection/lection9.html
@@ -60,5 +60,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lessons/adjectivos-possessive.html
+++ b/public/lessons/adjectivos-possessive.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adjectivos Possessive</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['adjectivos-possessive'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/adjectivos1.html
+++ b/public/lessons/adjectivos1.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adjectivos1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['adjectivos1'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/adjectivos2.html
+++ b/public/lessons/adjectivos2.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adjectivos2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['adjectivos2'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/adverbios1.html
+++ b/public/lessons/adverbios1.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adverbios1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['adverbios1'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/adverbios2.html
+++ b/public/lessons/adverbios2.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adverbios2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['adverbios2'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/adverbios3.html
+++ b/public/lessons/adverbios3.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adverbios3</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['adverbios3'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/alimentos.html
+++ b/public/lessons/alimentos.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Alimentos</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['alimentos'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/animales.html
+++ b/public/lessons/animales.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Animales</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['animales'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/basico1.html
+++ b/public/lessons/basico1.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Basico1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['basico1'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/basico2.html
+++ b/public/lessons/basico2.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Basico2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['basico2'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/colores.html
+++ b/public/lessons/colores.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Colores</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['colores'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/conjunctiones.html
+++ b/public/lessons/conjunctiones.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Conjunctiones</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['conjunctiones'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/datas-tempore.html
+++ b/public/lessons/datas-tempore.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Datas Tempore</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['datas-tempore'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/demonstrativos1.html
+++ b/public/lessons/demonstrativos1.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Demonstrativos1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['demonstrativos1'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/esser-haber.html
+++ b/public/lessons/esser-haber.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Esser Haber</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['esser-haber'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/familia.html
+++ b/public/lessons/familia.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Familia</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['familia'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/negativos.html
+++ b/public/lessons/negativos.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Negativos</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['negativos'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/numeros.html
+++ b/public/lessons/numeros.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Numeros</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['numeros'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/occupationes.html
+++ b/public/lessons/occupationes.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Occupationes</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['occupationes'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/phrases-quotidian.html
+++ b/public/lessons/phrases-quotidian.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Phrases Quotidian</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['phrases-quotidian'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/plurales.html
+++ b/public/lessons/plurales.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Plurales</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['plurales'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/possessives2.html
+++ b/public/lessons/possessives2.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Possessives2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['possessives2'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/prender-casa.html
+++ b/public/lessons/prender-casa.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Prender Casa</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['prender-casa'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/prepositiones.html
+++ b/public/lessons/prepositiones.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Prepositiones</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['prepositiones'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/presente1.html
+++ b/public/lessons/presente1.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Presente1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['presente1'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/questiones.html
+++ b/public/lessons/questiones.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Questiones</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['questiones'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/technologia.html
+++ b/public/lessons/technologia.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Technologia</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['technologia'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/verbos2.html
+++ b/public/lessons/verbos2.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['verbos2'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/verbos3.html
+++ b/public/lessons/verbos3.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos3</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['verbos3'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/verbos4.html
+++ b/public/lessons/verbos4.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos4</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['verbos4'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/verbos5.html
+++ b/public/lessons/verbos5.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos5</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['verbos5'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/verbos6.html
+++ b/public/lessons/verbos6.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos6</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['verbos6'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>

--- a/public/lessons/vestimentos.html
+++ b/public/lessons/vestimentos.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Vestimentos</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped" id="vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+    <section class="card exercise mb-4">
+  <h3>Traduce</h3>
+  <form id="exercise-form" class="exercise-grid"></form>
+  <div class="mt-3">
+    <button class="btn btn-success btn-comprobar">Comprobar</button>
+    <button class="btn btn-danger btn-borrar">Borrar</button>
+  </div>
+  <div class="feedback mt-2"></div>
+</section>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+  import data from '/public/data/vocab.json' assert { type: 'json' };
+  const rows = data['vestimentos'] || [];
+  const tbody = document.querySelector('#vocab-table tbody');
+  rows.forEach(({term,answer})=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${term}</td><td>${answer}</td>`;
+    tbody.appendChild(tr);
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add nav.js with dynamic 'Curso' dropdown entries
- load nav.js in index, lection and appendice pages
- create 33 lesson pages under `public/lessons`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d2b754100832c9d83601cfd0239d5