### PR TITLE
Add responsive curso layout

### DIFF
--- a/public/appendice/contos.html
+++ b/public/appendice/contos.html
@@ -39,5 +39,6 @@
   <footer></footer>
   <script src="/js/tooltip.js"></script>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/appendice/grammatica.html
+++ b/public/appendice/grammatica.html
@@ -177,5 +177,6 @@
   <footer></footer>
   <script src="/js/tooltip.js"></script>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/appendice/numeros.html
+++ b/public/appendice/numeros.html
@@ -91,6 +91,7 @@
   <footer></footer>
   <script src="/js/tooltip.js"></script>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>
 k

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -363,3 +363,48 @@ main {
     position: static;
   }
 }
+
+/* --- Curso buttons grid --- */
+.curso-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1rem;
+  text-align: center;
+  margin: 2rem 0;
+}
+
+@media (max-width: 900px) {
+  .curso-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.curso-btn {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: var(--primary-color);
+  color: #fff;
+  border-radius: 50%;
+  aspect-ratio: 1 / 1;
+  padding: 1rem;
+  font-size: 0.9rem;
+  gap: 0.25rem;
+}
+
+.curso-btn i {
+  font-size: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .curso-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 400px) {
+  .curso-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/public/curso.html
+++ b/public/curso.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Curso</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="curso-grid" id="curso-grid"></section>
+  </main>
+  <footer></footer>
+
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script type="module">
+    const grid = document.getElementById('curso-grid');
+    window.cursoSlugs.forEach(slug => {
+      const icon = window.iconMap[slug] || 'fas fa-book';
+      const a = document.createElement('a');
+      a.href = `/lessons/${slug}.html`;
+      a.className = 'curso-btn';
+      const title = slug.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ');
+      a.innerHTML = `<i class="${icon}"></i><span>${title}</span>`;
+      grid.appendChild(a);
+    });
+  </script>
+</body>
+</html>
+

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,7 @@
 
   <!-- Scripts -->
   <script src="js/include.js"></script>
+  <script src="js/nav.js"></script>
   <script src="js/tooltip.js"></script>
   <script>
     // Navegación interna para Home y Appendice

--- a/public/js/include.js
+++ b/public/js/include.js
@@ -2,7 +2,9 @@ document.addEventListener("DOMContentLoaded", function () {
   const path = location.pathname;
 
   // Determinar si estamos en una subcarpeta
-  const base = path.includes("/lection/") || path.includes("/appendice/")
+  const base = path.includes("/lection/") ||
+               path.includes("/appendice/") ||
+               path.includes("/lessons/")
     ? "../components/"
     : "components/";
 

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -1,0 +1,75 @@
+const cursoSlugs = [
+  "basico1","basico2","phrases-quotidian","alimentos","animales",
+  "adjectivos1","plurales","esser-haber","vestimentos",
+  "adjectivos-possessive","colores","presente1","demonstrativos1",
+  "conjunctiones","questiones","verbos2","adjectivos2",
+  "prepositiones","numeros","familia","possessives2","verbos3",
+  "datas-tempore","verbos4","adverbios1","verbos5","adverbios2",
+  "occupationes","verbos6","negativos","adverbios3",
+  "prender-casa","technologia"
+];
+
+const iconMap = {
+  basico1: 'fas fa-lightbulb',
+  basico2: 'fas fa-lightbulb',
+  'phrases-quotidian': 'fas fa-comment-dots',
+  alimentos: 'fas fa-apple-alt',
+  animales: 'fas fa-dog',
+  adjectivos1: 'fas fa-font',
+  plurales: 'fas fa-clone',
+  'esser-haber': 'fas fa-check-double',
+  vestimentos: 'fas fa-tshirt',
+  'adjectivos-possessive': 'fas fa-hand-holding-heart',
+  colores: 'fas fa-palette',
+  presente1: 'fas fa-clock',
+  demonstrativos1: 'fas fa-hand-point-up',
+  conjunctiones: 'fas fa-link',
+  questiones: 'fas fa-question-circle',
+  verbos2: 'fas fa-running',
+  adjectivos2: 'fas fa-font',
+  prepositiones: 'fas fa-map-signs',
+  numeros: 'fas fa-sort-numeric-up',
+  familia: 'fas fa-users',
+  possessives2: 'fas fa-hand-holding-heart',
+  verbos3: 'fas fa-running',
+  'datas-tempore': 'fas fa-calendar-alt',
+  verbos4: 'fas fa-running',
+  adverbios1: 'fas fa-rocket',
+  verbos5: 'fas fa-running',
+  adverbios2: 'fas fa-rocket',
+  occupationes: 'fas fa-briefcase',
+  verbos6: 'fas fa-running',
+  negativos: 'fas fa-ban',
+  adverbios3: 'fas fa-rocket',
+  'prender-casa': 'fas fa-home',
+  technologia: 'fas fa-microchip'
+};
+
+window.cursoSlugs = cursoSlugs;
+window.iconMap = iconMap;
+
+function toTitle(str) {
+  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ');
+}
+
+function buildCursoLink() {
+  const navLinks = document.querySelector('.nav-links');
+  if (!navLinks) return;
+  const li = document.createElement('li');
+  const a = document.createElement('a');
+  a.href = '/curso.html';
+  a.textContent = 'Curso';
+  li.appendChild(a);
+  const first = navLinks.firstElementChild;
+  if (first) navLinks.insertBefore(li, first);
+  else navLinks.appendChild(li);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const timer = setInterval(() => {
+    if (document.querySelector('.nav-links')) {
+      clearInterval(timer);
+      buildCursoLink();
+    }
+  }, 50);
+});

--- a/public/lection/lection1.html
+++ b/public/lection/lection1.html
@@ -65,5 +65,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection10.html
+++ b/public/lection/lection10.html
@@ -62,5 +62,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection2.html
+++ b/public/lection/lection2.html
@@ -60,5 +60,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection3.html
+++ b/public/lection/lection3.html
@@ -51,5 +51,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection4.html
+++ b/public/lection/lection4.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection5.html
+++ b/public/lection/lection5.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection6.html
+++ b/public/lection/lection6.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection7.html
+++ b/public/lection/lection7.html
@@ -61,5 +61,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection8.html
+++ b/public/lection/lection8.html
@@ -62,5 +62,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lection/lection9.html
+++ b/public/lection/lection9.html
@@ -60,5 +60,6 @@
   <!-- Footer externo -->
   <footer></footer>
   <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
 </body>
 </html>

--- a/public/lessons/adjectivos-possessive.html
+++ b/public/lessons/adjectivos-possessive.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adjectivos Possessive</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="adjectivos-possessive"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/adjectivos1.html
+++ b/public/lessons/adjectivos1.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adjectivos1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="adjectivos1"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/adjectivos2.html
+++ b/public/lessons/adjectivos2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adjectivos2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="adjectivos2"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/adverbios1.html
+++ b/public/lessons/adverbios1.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adverbios1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="adverbios1"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/adverbios2.html
+++ b/public/lessons/adverbios2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adverbios2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="adverbios2"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/adverbios3.html
+++ b/public/lessons/adverbios3.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Adverbios3</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="adverbios3"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/alimentos.html
+++ b/public/lessons/alimentos.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Alimentos</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="alimentos"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/animales.html
+++ b/public/lessons/animales.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Animales</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="animales"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/basico1.html
+++ b/public/lessons/basico1.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Basico1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="basico1"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/basico2.html
+++ b/public/lessons/basico2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Basico2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="basico2"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/colores.html
+++ b/public/lessons/colores.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Colores</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="colores"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/conjunctiones.html
+++ b/public/lessons/conjunctiones.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Conjunctiones</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="conjunctiones"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/datas-tempore.html
+++ b/public/lessons/datas-tempore.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Datas Tempore</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="datas-tempore"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/demonstrativos1.html
+++ b/public/lessons/demonstrativos1.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Demonstrativos1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="demonstrativos1"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/esser-haber.html
+++ b/public/lessons/esser-haber.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Esser Haber</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="esser-haber"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/familia.html
+++ b/public/lessons/familia.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Familia</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="familia"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/negativos.html
+++ b/public/lessons/negativos.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Negativos</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="negativos"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/numeros.html
+++ b/public/lessons/numeros.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Numeros</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="numeros"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/occupationes.html
+++ b/public/lessons/occupationes.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Occupationes</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="occupationes"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/phrases-quotidian.html
+++ b/public/lessons/phrases-quotidian.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Phrases Quotidian</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="phrases-quotidian"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/plurales.html
+++ b/public/lessons/plurales.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Plurales</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="plurales"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/possessives2.html
+++ b/public/lessons/possessives2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Possessives2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="possessives2"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/prender-casa.html
+++ b/public/lessons/prender-casa.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Prender Casa</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="prender-casa"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/prepositiones.html
+++ b/public/lessons/prepositiones.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Prepositiones</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="prepositiones"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/presente1.html
+++ b/public/lessons/presente1.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Presente1</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="presente1"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/questiones.html
+++ b/public/lessons/questiones.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Questiones</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="questiones"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/technologia.html
+++ b/public/lessons/technologia.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Technologia</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="technologia"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/verbos2.html
+++ b/public/lessons/verbos2.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos2</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="verbos2"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/verbos3.html
+++ b/public/lessons/verbos3.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos3</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="verbos3"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/verbos4.html
+++ b/public/lessons/verbos4.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos4</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="verbos4"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/verbos5.html
+++ b/public/lessons/verbos5.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos5</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="verbos5"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/verbos6.html
+++ b/public/lessons/verbos6.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Verbos6</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="verbos6"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>

--- a/public/lessons/vestimentos.html
+++ b/public/lessons/vestimentos.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Schola Interlingua - Vestimentos</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section id="vocab">
+      <h2>Vocabulario</h2>
+      <table class="table table-striped vocab-table">
+        <thead><tr><th>Interlingua</th><th>Español</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  <div id="exercise-container" data-lesson="vestimentos"></div>
+  <script src="/js/exercises.js"></script>
+  <script src="/js/tooltip.js"></script>
+  <script src="/js/vocab-table.js"></script>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make the course grid adapt to tablet and phone widths
- place the Curso link before Lectiones in the navbar

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d2b754100832c9d83601cfd0239d5