### PR TITLE
Add interactive quiz to lessons

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -343,6 +343,44 @@ main {
 .vocab-toggle:hover {
   background: #0a3a63;
 }
+
+/* Quiz */
+.quiz-card {
+  max-width: 500px;
+  margin: 0 auto 2rem;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.quiz-option {
+  display: block;
+  width: 100%;
+  padding: 0.6rem 1.5rem;
+  font-size: 1.1rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.quiz-option:hover {
+  background: #0a3a63;
+}
+
+.quiz-option.correct {
+  background: #198754;
+}
+
+.quiz-option.incorrect {
+  background: #dc3545;
+}
 @media (max-width: 600px) {
   .flex-two {
     flex-direction: column;

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1,0 +1,62 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('quiz-container');
+  if (!container) return;
+
+  const lang = localStorage.getItem('lang') || 'es';
+
+  function init() {
+    if (!window.items || !window.items.length) {
+      setTimeout(init, 100);
+      return;
+    }
+
+    const card = document.createElement('section');
+    card.className = 'card quiz-card';
+    const questionEl = document.createElement('h3');
+    const optionsEl = document.createElement('div');
+    optionsEl.className = 'quiz-options';
+    card.appendChild(questionEl);
+    card.appendChild(optionsEl);
+    container.appendChild(card);
+
+    let remaining = [...items];
+
+    function nextQuestion() {
+      optionsEl.innerHTML = '';
+      if (remaining.length === 0) remaining = [...items];
+      const index = Math.floor(Math.random() * remaining.length);
+      const item = remaining.splice(index, 1)[0];
+      questionEl.textContent = item[lang] || item.es;
+
+      const distractors = items.filter(i => i.term !== item.term);
+      distractors.sort(() => Math.random() - 0.5);
+      const choices = [item.term, ...distractors.slice(0, 3).map(i => i.term)];
+      choices.sort(() => Math.random() - 0.5);
+
+      choices.forEach(choice => {
+        const btn = document.createElement('button');
+        btn.className = 'quiz-option';
+        btn.textContent = choice;
+        btn.addEventListener('click', () => {
+          optionsEl.querySelectorAll('button').forEach(b => (b.disabled = true));
+          const correctBtn = [...optionsEl.children].find(
+            b => b.textContent === item.term
+          );
+          if (choice === item.term) {
+            btn.classList.add('correct');
+          } else {
+            btn.classList.add('incorrect');
+            if (correctBtn) correctBtn.classList.add('correct');
+          }
+          setTimeout(nextQuestion, 1000);
+        });
+        optionsEl.appendChild(btn);
+      });
+    }
+
+    nextQuestion();
+  }
+
+  init();
+});
+

--- a/public/lection/lection1.html
+++ b/public/lection/lection1.html
@@ -57,7 +57,9 @@
     </ul>
     </section>
     </div>
+      <div id="quiz-container"></div>
       <div id="exercise-container" data-lesson="1"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection10.html
+++ b/public/lection/lection10.html
@@ -54,7 +54,9 @@
             </ul>
       </section>
     </div>
+            <div id="quiz-container"></div>
             <div id="exercise-container" data-lesson="10"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection2.html
+++ b/public/lection/lection2.html
@@ -52,7 +52,9 @@
           </ul>
       </section>
     </div>
+      <div id="quiz-container"></div>
       <div id="exercise-container" data-lesson="2"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection3.html
+++ b/public/lection/lection3.html
@@ -43,7 +43,9 @@
         <tbody></tbody>
       </table>
     </div>
+        <div id="quiz-container"></div>
         <div id="exercise-container" data-lesson="3"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection4.html
+++ b/public/lection/lection4.html
@@ -53,7 +53,9 @@
             </ul>
       </section>
     </div>
+            <div id="quiz-container"></div>
             <div id="exercise-container" data-lesson="4"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection5.html
+++ b/public/lection/lection5.html
@@ -53,7 +53,9 @@
       </section>
 
     </div>
+            <div id="quiz-container"></div>
             <div id="exercise-container" data-lesson="5"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection6.html
+++ b/public/lection/lection6.html
@@ -53,7 +53,9 @@
             </ul>
       </section>
     </div>
+        <div id="quiz-container"></div>
         <div id="exercise-container" data-lesson="6"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection7.html
+++ b/public/lection/lection7.html
@@ -53,7 +53,9 @@
             </ul>
       </section>
     </div>
+        <div id="quiz-container"></div>
         <div id="exercise-container" data-lesson="7"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection8.html
+++ b/public/lection/lection8.html
@@ -54,7 +54,9 @@
             </ul>
       </section>
     </div>
+            <div id="quiz-container"></div>
             <div id="exercise-container" data-lesson="8"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lection/lection9.html
+++ b/public/lection/lection9.html
@@ -52,7 +52,9 @@
             </ul>
       </section>
     </div>
+            <div id="quiz-container"></div>
             <div id="exercise-container" data-lesson="9"></div>
+<script src="/js/quiz.js"></script>
 <script src="/js/exercises.js"></script>
 <script src="/js/tooltip.js"></script>
 <script src="/js/vocab-table.js"></script>

--- a/public/lessons/adjectivos-possessive.html
+++ b/public/lessons/adjectivos-possessive.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="adjectivos-possessive"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/adjectivos1.html
+++ b/public/lessons/adjectivos1.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="adjectivos1"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/adjectivos2.html
+++ b/public/lessons/adjectivos2.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="adjectivos2"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/adverbios1.html
+++ b/public/lessons/adverbios1.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="adverbios1"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/adverbios2.html
+++ b/public/lessons/adverbios2.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="adverbios2"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/adverbios3.html
+++ b/public/lessons/adverbios3.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="adverbios3"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/alimentos.html
+++ b/public/lessons/alimentos.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="alimentos"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/animales.html
+++ b/public/lessons/animales.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="animales"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/basico1.html
+++ b/public/lessons/basico1.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="basico1"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/basico2.html
+++ b/public/lessons/basico2.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="basico2"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/colores.html
+++ b/public/lessons/colores.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="colores"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/conjunctiones.html
+++ b/public/lessons/conjunctiones.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="conjunctiones"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/datas-tempore.html
+++ b/public/lessons/datas-tempore.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="datas-tempore"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/demonstrativos1.html
+++ b/public/lessons/demonstrativos1.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="demonstrativos1"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/esser-haber.html
+++ b/public/lessons/esser-haber.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="esser-haber"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/familia.html
+++ b/public/lessons/familia.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="familia"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/negativos.html
+++ b/public/lessons/negativos.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="negativos"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/numeros.html
+++ b/public/lessons/numeros.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="numeros"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/occupationes.html
+++ b/public/lessons/occupationes.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="occupationes"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/phrases-quotidian.html
+++ b/public/lessons/phrases-quotidian.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="phrases-quotidian"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/plurales.html
+++ b/public/lessons/plurales.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="plurales"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/possessives2.html
+++ b/public/lessons/possessives2.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="possessives2"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/prender-casa.html
+++ b/public/lessons/prender-casa.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="prender-casa"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/prepositiones.html
+++ b/public/lessons/prepositiones.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="prepositiones"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/presente1.html
+++ b/public/lessons/presente1.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="presente1"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/questiones.html
+++ b/public/lessons/questiones.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="questiones"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/technologia.html
+++ b/public/lessons/technologia.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="technologia"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/verbos2.html
+++ b/public/lessons/verbos2.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="verbos2"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/verbos3.html
+++ b/public/lessons/verbos3.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="verbos3"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/verbos4.html
+++ b/public/lessons/verbos4.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="verbos4"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/verbos5.html
+++ b/public/lessons/verbos5.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="verbos5"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/verbos6.html
+++ b/public/lessons/verbos6.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="verbos6"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>

--- a/public/lessons/vestimentos.html
+++ b/public/lessons/vestimentos.html
@@ -22,7 +22,9 @@
         <tbody></tbody>
       </table>
     </section>
+  <div id="quiz-container"></div>
   <div id="exercise-container" data-lesson="vestimentos"></div>
+  <script src="/js/quiz.js"></script>
   <script src="/js/exercises.js"></script>
   <script src="/js/tooltip.js"></script>
   <script src="/js/vocab-table.js"></script>


### PR DESCRIPTION
## Summary
- add quiz.js with multiple-choice activity using lesson vocabulary
- style quiz card and buttons to match existing theme
- include quiz container and script across all lesson and lection pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e823c5660832c8ec5badf64718a3c