### PR TITLE
Add course-wide Anki export

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,9 @@
         <button id="import-progress" class="btn btn-secondary">Importar le progresso</button>
       </div>
     </section>
+    <div class="card">
+      <button id="download-anki-all" class="btn btn-secondary">Descargar Anki de todo el curso</button>
+    </div>
     <!-- Sección Home / Prefacio -->
     <section id="home-section" class="card">
       <h1>Benvenite a Schola Interlingua!</h1>
@@ -64,6 +67,7 @@
   <script src="js/include.js"></script>
   <script src="js/nav.js"></script>
   <script src="js/tooltip.js"></script>
+  <script src="js/anki-all.js"></script>
   <script>
     // Navegación interna para Home y Appendice
     document.addEventListener("DOMContentLoaded", () => {

--- a/public/js/anki-all.js
+++ b/public/js/anki-all.js
@@ -1,0 +1,32 @@
+(function() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('download-anki-all');
+    if (!btn) return;
+
+    btn.addEventListener('click', async () => {
+      const lang = localStorage.getItem('lang') || 'es';
+      const sanitize = str => str.replace(/[\t\n,]/g, ' ');
+      const data = await fetch('/data/vocab.json').then(r => r.json());
+      const lines = [];
+
+      Object.keys(data).forEach(lessonId => {
+        (data[lessonId] || []).forEach(entry => {
+          if (!entry.term) return;
+          const trans = entry[lang];
+          if (!trans) return;
+          const term = sanitize(entry.term);
+          const translation = sanitize(trans);
+          lines.push(`${term},${translation},Lesson${lessonId}`);
+        });
+      });
+
+      const blob = new Blob([lines.join('\n')], { type: 'text/plain;charset=utf-8' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `anki_schola_interlingua_${lang}_all_lessons.txt`;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    });
+  });
+})();
+


### PR DESCRIPTION
## Summary
- Add "Descargar Anki de todo el curso" button on index page
- Implement script to gather all vocabulary and download as Anki-ready text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890fc3119b8832c8a0d104a5af3e35c