### PR TITLE
Add course-wide Anki export

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,9 @@
         <button id="import-progress" class="btn btn-secondary">Importar le progresso</button>
       </div>
     </section>
+      <div class="card">
+        <button id="download-anki-all" class="btn btn-primary" aria-label="Descargar Anki de todo el curso" title="Se descarga un archivo con subdecks por lección">Descargar Anki de todo el curso</button>
+      </div>
     <!-- Sección Home / Prefacio -->
     <section id="home-section" class="card">
       <h1>Benvenite a Schola Interlingua!</h1>
@@ -64,6 +67,7 @@
   <script src="js/include.js"></script>
   <script src="js/nav.js"></script>
   <script src="js/tooltip.js"></script>
+  <script src="js/anki-all.js"></script>
   <script>
     // Navegación interna para Home y Appendice
     document.addEventListener("DOMContentLoaded", () => {

--- a/public/js/anki-all.js
+++ b/public/js/anki-all.js
@@ -1,0 +1,58 @@
+(function() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('download-anki-all');
+    if (!btn) return;
+
+    btn.addEventListener('click', async () => {
+      const original = btn.textContent;
+      btn.textContent = 'Generando…';
+      btn.disabled = true;
+      btn.style.opacity = '0.7';
+
+      try {
+        const lang = localStorage.getItem('lang') || 'es';
+        const sanitize = str => String(str || '').replace(/[\n\r,]/g, ' ').trim();
+        const data = await fetch('/data/vocab.json').then(r => r.json());
+        const order = Array.from({ length: 10 }, (_, i) => `lection${i + 1}`)
+          .concat(window.cursoSlugs || []);
+        const lines = [];
+        const seen = new Set();
+
+        order.forEach((lessonId, idx) => {
+          const key = lessonId.startsWith('lection') ? lessonId.replace('lection', '') : lessonId;
+          const items = data[key] || [];
+          const title = (lessonId.startsWith('lection')
+            ? `Lection ${lessonId.replace('lection', '')}`
+            : lessonId.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ')
+          ).replace(/,/g, '');
+          const deck = `Schola Interlingua::Lesson ${String(idx + 1).padStart(2, '0')} - ${title}`;
+
+          items.forEach(entry => {
+            if (!entry.term) return;
+            const trans = sanitize(entry[lang]);
+            if (!trans) return;
+            const term = sanitize(entry.term);
+            const line = `${term},${trans},${deck}`;
+            if (!seen.has(line)) {
+              lines.push(line);
+              seen.add(line);
+            }
+          });
+        });
+
+        const blob = new Blob([lines.join('\n')], { type: 'text/plain;charset=utf-8' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `anki_schola_interlingua_${lang}_all_lessons.txt`;
+        a.click();
+        URL.revokeObjectURL(a.href);
+      } catch (e) {
+        console.error('No se pudo generar el archivo Anki:', e);
+      } finally {
+        btn.disabled = false;
+        btn.textContent = original;
+        btn.style.opacity = '';
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- Add primary-styled "Descargar Anki de todo el curso" button with tooltip and accessibility
- Build full-course Anki exporter that creates subdeck file `Schola Interlingua::Lesson XX - Title` and disables button while generating

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6890fc3119b8832c8a0d104a5af3e35c