### PR TITLE
Use lesson slug as Anki deck name

### DIFF
--- a/public/js/anki-all.js
+++ b/public/js/anki-all.js
@@ -21,11 +21,11 @@
         order.forEach((lessonId, idx) => {
           const key = lessonId.startsWith('lection') ? lessonId.replace('lection', '') : lessonId;
           const items = data[key] || [];
-          const title = (lessonId.startsWith('lection')
-            ? `Lection ${lessonId.replace('lection', '')}`
-            : lessonId.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ')
-          ).replace(/,/g, '');
-          const deck = `Schola Interlingua::Lesson ${String(idx + 1).padStart(2, '0')} - ${title}`;
+          const deck = sanitize(
+            lessonId.startsWith('lection')
+              ? `Lection${lessonId.replace('lection', '')}`
+              : lessonId.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+          );
 
           items.forEach(entry => {
             if (!entry.term) return;

--- a/public/js/anki.js
+++ b/public/js/anki.js
@@ -14,19 +14,22 @@
     clone.addEventListener('click', () => {
       const lang = localStorage.getItem('lang') || 'es';
       const sanitize = str => str.replace(/[\t\n,]/g, ' ');
+      const basename = location.pathname.split('/').pop().replace(/\.html$/,'');
+      const deck = sanitize(
+        basename.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+      );
       const lines = (window.items || [])
         .filter(it => it.term && (it[lang] || it.es))
         .map(it => {
           const term = sanitize(it.term);
           const trans = sanitize(it[lang] || it.es);
-          return `${term},${trans}`;
+          return `${term},${trans},${deck}`;
         })
         .join('\n');
 
       const blob = new Blob([lines], {type:'text/plain;charset=utf-8'});
       const link = document.createElement('a');
       link.href = URL.createObjectURL(blob);
-      const basename = location.pathname.split('/').pop().replace(/\.html$/,'');
       link.download = `${basename}-anki.txt`;
       link.click();
       URL.revokeObjectURL(link.href);


### PR DESCRIPTION
## Summary
- Generate Anki deck names from lesson slugs/titles instead of course-prefixed names
- Include deck name as third column in exported vocab lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891210a90fc832caf9b6e6e2e9e8a05