### PR TITLE
Add interactive games section

### DIFF
--- a/public/components/navbar.html
+++ b/public/components/navbar.html
@@ -20,6 +20,7 @@
           <li><a href="/lection/lection10.html">Lection 10</a></li>
         </ul>
       </li>
+      <li><a href="/games/index.html">Juegos</a></li>
       <li class="dropdown">
         <a href="#">Appendice ▼</a>
         <ul class="dropdown-menu">

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -499,3 +499,66 @@ main {
     grid-template-columns: 1fr;
   }
 }
+
+/* Juegos */
+.memory-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 10px;
+  margin-top: 1rem;
+}
+
+.memory-card {
+  background: var(--card-bg);
+  border: 1px solid #ccc;
+  border-radius: var(--radius);
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.match-container {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.match-column {
+  flex: 1;
+}
+
+.match-item {
+  display: block;
+  width: 100%;
+  margin: 4px 0;
+}
+
+.match-item.selected {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.wordsearch-grid {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 2px;
+  margin-top: 1rem;
+}
+
+.wordsearch-grid button {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  text-transform: uppercase;
+}
+
+.wordsearch-grid button.selected {
+  background: #bbdefb;
+}
+
+.wordsearch-grid button.found {
+  background: #c8e6c9;
+}

--- a/public/games/fill-blank.html
+++ b/public/games/fill-blank.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Completar huecos</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main class="card">
+    <h1>Completar huecos</h1>
+    <a href="index.html" class="btn btn-secondary">Volver a Juegos</a>
+    <form id="blank-form" class="blank-form" aria-label="Formulario de completar">
+      <p id="blank-phrase"></p>
+      <button type="submit" class="btn btn-primary">Enviar</button>
+    </form>
+    <p id="blank-feedback" aria-live="polite"></p>
+    <button id="blank-next" class="btn btn-secondary" style="display:none">Nueva frase</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const phraseEl = document.getElementById('blank-phrase');
+    const form = document.getElementById('blank-form');
+    const feedback = document.getElementById('blank-feedback');
+    const nextBtn = document.getElementById('blank-next');
+    const lang = gamesCommon.getLang();
+    let answer = '';
+
+    async function loadPhrase() {
+      const [entry] = await gamesCommon.getRandomEntries(1);
+      const words = (entry[lang] || entry['es']).split(' ');
+      const idx = Math.floor(Math.random()*words.length);
+      answer = words[idx];
+      phraseEl.innerHTML = '';
+      words.forEach((w,i) => {
+        if (i === idx) {
+          const inp = document.createElement('input');
+          inp.id = 'blank-input';
+          inp.setAttribute('aria-label','Respuesta');
+          inp.required = true;
+          phraseEl.appendChild(inp);
+        } else {
+          phraseEl.appendChild(document.createTextNode(w + ' '));
+        }
+      });
+      feedback.textContent = '';
+      nextBtn.style.display = 'none';
+      document.getElementById('blank-input').focus();
+    }
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const val = document.getElementById('blank-input').value.trim();
+      if (val.toLowerCase() === answer.toLowerCase()) {
+        feedback.textContent = 'Correcto';
+        feedback.style.color = 'green';
+      } else {
+        feedback.textContent = `Incorrecto: ${answer}`;
+        feedback.style.color = 'red';
+      }
+      nextBtn.style.display = 'inline-block';
+    });
+
+    nextBtn.addEventListener('click', loadPhrase);
+    loadPhrase();
+  });
+  </script>
+</body>
+</html>

--- a/public/games/index.html
+++ b/public/games/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Schola Interlingua - Juegos</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main class="card">
+    <h1>Juegos</h1>
+    <ul class="game-list">
+      <li><a href="memory.html" class="btn btn-primary">Parejas</a></li>
+      <li><a href="fill-blank.html" class="btn btn-primary">Completar huecos</a></li>
+      <li><a href="match.html" class="btn btn-primary">Unir pares</a></li>
+      <li><a href="odd-one.html" class="btn btn-primary">El intruso</a></li>
+      <li><a href="wordsearch.html" class="btn btn-primary">Sopa de letras</a></li>
+    </ul>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/games/match.html
+++ b/public/games/match.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Unir pares</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main class="card">
+    <h1>Unir pares</h1>
+    <a href="index.html" class="btn btn-secondary">Volver a Juegos</a>
+    <div id="match-container" class="match-container" role="group">
+      <div class="match-column" id="terms" aria-label="Términos"></div>
+      <div class="match-column" id="defs" aria-label="Definiciones"></div>
+    </div>
+    <p id="match-feedback" aria-live="polite"></p>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const lang = gamesCommon.getLang();
+    const termsCol = document.getElementById('terms');
+    const defsCol = document.getElementById('defs');
+    const feedback = document.getElementById('match-feedback');
+    let selected = null;
+
+    const entries = await gamesCommon.getRandomEntries(5);
+    const termButtons = [];
+    const defButtons = [];
+    entries.forEach(e => {
+      const tBtn = document.createElement('button');
+      tBtn.textContent = e.term;
+      tBtn.className = 'match-item';
+      tBtn.dataset.term = e.term;
+      tBtn.addEventListener('click', () => {
+        if (tBtn.disabled) return;
+        if (selected) selected.classList.remove('selected');
+        selected = tBtn;
+        tBtn.classList.add('selected');
+      });
+      termsCol.appendChild(tBtn);
+      termButtons.push(tBtn);
+
+      const dBtn = document.createElement('button');
+      dBtn.textContent = e[lang] || e['es'];
+      dBtn.className = 'match-item';
+      dBtn.dataset.term = e.term;
+      dBtn.addEventListener('click', () => {
+        if (!selected || dBtn.disabled) return;
+        if (dBtn.dataset.term === selected.dataset.term) {
+          dBtn.disabled = true;
+          selected.disabled = true;
+          dBtn.classList.add('matched');
+          selected.classList.remove('selected');
+          selected = null;
+          if (termButtons.every(b => b.disabled)) {
+            feedback.textContent = '¡Bien hecho!';
+          }
+        } else {
+          feedback.textContent = 'Incorrecto';
+        }
+      });
+      defButtons.push(dBtn);
+    });
+
+    gamesCommon.shuffle(defButtons).forEach(btn => defsCol.appendChild(btn));
+  });
+  </script>
+</body>
+</html>

--- a/public/games/memory.html
+++ b/public/games/memory.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Parejas</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main class="card">
+    <h1>Parejas</h1>
+    <a href="index.html" class="btn btn-secondary">Volver a Juegos</a>
+    <div id="memory-board" class="memory-board" role="grid"></div>
+    <p id="memory-score" aria-live="polite"></p>
+    <button id="memory-restart" class="btn btn-primary" style="display:none">Reiniciar</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const board = document.getElementById('memory-board');
+    const score = document.getElementById('memory-score');
+    const restart = document.getElementById('memory-restart');
+    const lang = gamesCommon.getLang();
+    let first = null;
+    let lock = false;
+    let moves = 0;
+
+    async function setup() {
+      const entries = await gamesCommon.getRandomEntries(4);
+      const cards = [];
+      entries.forEach(e => {
+        const trans = e[lang] || e['es'];
+        cards.push({ id: e.term, text: e.term });
+        cards.push({ id: e.term, text: trans });
+      });
+      gamesCommon.shuffle(cards);
+      board.innerHTML = '';
+      score.textContent = '';
+      restart.style.display = 'none';
+      first = null; moves = 0; lock = false;
+      cards.forEach(c => {
+        const btn = document.createElement('button');
+        btn.className = 'memory-card';
+        btn.setAttribute('data-id', c.id);
+        btn.setAttribute('aria-label', 'carta');
+        btn.addEventListener('click', () => flip(btn, c.text));
+        board.appendChild(btn);
+      });
+    }
+
+    function flip(card, text) {
+      if (lock || card.classList.contains('matched') || card.textContent) return;
+      card.textContent = text;
+      if (!first) {
+        first = card;
+      } else {
+        moves++;
+        if (first.dataset.id === card.dataset.id && first !== card) {
+          first.classList.add('matched');
+          card.classList.add('matched');
+          first = null;
+          if (board.querySelectorAll('.matched').length === board.children.length) {
+            score.textContent = `Completado en ${moves} movimientos`;
+            restart.style.display = 'inline-block';
+          }
+        } else {
+          lock = true;
+          setTimeout(() => {
+            first.textContent = '';
+            card.textContent = '';
+            first = null;
+            lock = false;
+          }, 800);
+        }
+      }
+    }
+
+    restart.addEventListener('click', setup);
+    setup();
+  });
+  </script>
+</body>
+</html>

--- a/public/games/odd-one.html
+++ b/public/games/odd-one.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>El intruso</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main class="card">
+    <h1>El intruso</h1>
+    <a href="index.html" class="btn btn-secondary">Volver a Juegos</a>
+    <ul id="odd-list" class="odd-list"></ul>
+    <p id="odd-feedback" aria-live="polite"></p>
+    <button id="odd-next" class="btn btn-secondary">Próximo</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const list = document.getElementById('odd-list');
+    const feedback = document.getElementById('odd-feedback');
+    const nextBtn = document.getElementById('odd-next');
+    const lang = gamesCommon.getLang();
+    let correct = null;
+    let allEntries = [];
+
+    async function initData() {
+      allEntries = await gamesCommon.loadVocab();
+      newRound();
+    }
+
+    function newRound() {
+      feedback.textContent = '';
+      list.innerHTML = '';
+      const groups = Array.from(new Set(allEntries.map(e => e.group)));
+      const group = groups[Math.floor(Math.random()*groups.length)];
+      const groupWords = allEntries.filter(e => e.group === group);
+      const intruder = gamesCommon.shuffle(allEntries.filter(e => e.group !== group))[0];
+      const options = gamesCommon.shuffle([
+        ...gamesCommon.shuffle(groupWords).slice(0,3),
+        intruder
+      ]);
+      correct = intruder.term;
+      options.forEach(o => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = o[lang] || o['es'];
+        btn.className = 'btn btn-primary';
+        btn.addEventListener('click', () => {
+          if (o.term === correct) {
+            feedback.textContent = '¡Correcto!';
+          } else {
+            feedback.textContent = 'Intenta de nuevo';
+          }
+        });
+        li.appendChild(btn);
+        list.appendChild(li);
+      });
+    }
+
+    nextBtn.addEventListener('click', newRound);
+    initData();
+  });
+  </script>
+</body>
+</html>

--- a/public/games/wordsearch.html
+++ b/public/games/wordsearch.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Sopa de letras</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <nav></nav>
+  <main class="card">
+    <h1>Sopa de letras</h1>
+    <a href="index.html" class="btn btn-secondary">Volver a Juegos</a>
+    <div id="wordsearch" class="wordsearch-grid" role="grid"></div>
+    <ul id="wordsearch-list"></ul>
+    <p id="wordsearch-feedback" aria-live="polite"></p>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const gridEl = document.getElementById('wordsearch');
+    const listEl = document.getElementById('wordsearch-list');
+    const feedback = document.getElementById('wordsearch-feedback');
+    const size = 10;
+    let words = [];
+    let start = null;
+    let cells = [];
+
+    function posToIndex(r,c){ return r*size+c; }
+
+    function renderGrid(matrix){
+      gridEl.innerHTML='';
+      cells = [];
+      for(let r=0;r<size;r++){
+        for(let c=0;c<size;c++){
+          const btn=document.createElement('button');
+          btn.textContent=matrix[r][c];
+          btn.setAttribute('data-r',r);
+          btn.setAttribute('data-c',c);
+          btn.className='ws-cell';
+          btn.addEventListener('mousedown',startSelect);
+          btn.addEventListener('mouseover',moveSelect);
+          btn.addEventListener('mouseup',endSelect);
+          btn.addEventListener('mouseleave',()=>{});
+          gridEl.appendChild(btn);
+          cells.push(btn);
+        }
+      }
+    }
+
+    function startSelect(e){
+      clearSelection();
+      start=e.target;
+      start.classList.add('selected');
+      window.addEventListener('mouseup',cancelSelect);
+    }
+
+    function moveSelect(e){
+      if(!start||e.buttons===0)return;
+      clearSelection();
+      const sr=parseInt(start.dataset.r);const sc=parseInt(start.dataset.c);
+      const er=parseInt(e.target.dataset.r);const ec=parseInt(e.target.dataset.c);
+      if(sr===er||sc===ec){
+        const rStep=sr===er?0:(er>sr?1:-1);
+        const cStep=sc===ec?0:(ec>sc?1:-1);
+        let r=sr,c=sc;
+        while(true){
+          const btn=cells[posToIndex(r,c)];
+          btn.classList.add('selected');
+          if(r===er && c===ec) break;
+          r+=rStep;c+=cStep;
+        }
+      }
+    }
+
+    function endSelect(e){
+      if(!start) return;
+      const selected=[...gridEl.querySelectorAll('.selected')];
+      const letters=selected.map(b=>b.textContent).join('');
+      const reversed=selected.map(b=>b.textContent).reverse().join('');
+      const found=words.find(w=>w.word===letters||w.word===reversed);
+      if(found && !found.found){
+        selected.forEach(b=>b.classList.add('found'));
+        found.found=true;
+        updateList();
+        if(words.every(w=>w.found)) feedback.textContent='¡Completado!';
+      }
+      clearSelection();
+    }
+
+    function cancelSelect(){
+      clearSelection();
+    }
+
+    function clearSelection(){
+      gridEl.querySelectorAll('.selected').forEach(b=>b.classList.remove('selected'));
+      start=null;
+      window.removeEventListener('mouseup',cancelSelect);
+    }
+
+    function updateList(){
+      listEl.innerHTML='';
+      words.forEach(w=>{
+        const li=document.createElement('li');
+        li.textContent=w.word.toLowerCase();
+        if(w.found) li.style.textDecoration='line-through';
+        listEl.appendChild(li);
+      });
+    }
+
+    async function init(){
+      const entries=await gamesCommon.getRandomEntries(6);
+      words=entries.map(e=>({word:e.term.toUpperCase(), found:false}));
+      const matrix=Array.from({length:size},()=>Array(size).fill(null));
+      words.forEach(w=>{
+        const len=w.word.length;
+        let placed=false;let attempts=0;
+        while(!placed && attempts<100){
+          attempts++;
+          const dir=Math.random()<0.5?'H':'V';
+          const r=dir==='H'?Math.floor(Math.random()*size):Math.floor(Math.random()*(size-len));
+          const c=dir==='V'?Math.floor(Math.random()*size):Math.floor(Math.random()*(size-len));
+          let fits=true;
+          for(let i=0;i<len;i++){
+            const rr=dir==='H'?r:r+i;
+            const cc=dir==='H'?c+i:c;
+            if(matrix[rr][cc] && matrix[rr][cc]!==w.word[i]){fits=false;break;}
+          }
+          if(fits){
+            for(let i=0;i<len;i++){
+              const rr=dir==='H'?r:r+i;
+              const cc=dir==='H'?c+i:c;
+              matrix[rr][cc]=w.word[i];
+            }
+            placed=true;
+          }
+        }
+      });
+      const letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      for(let r=0;r<size;r++){
+        for(let c=0;c<size;c++){
+          if(!matrix[r][c]) matrix[r][c]=letters[Math.floor(Math.random()*letters.length)];
+        }
+      }
+      renderGrid(matrix);
+      updateList();
+    }
+
+    init();
+  });
+  </script>
+</body>
+</html>

--- a/public/js/games-common.js
+++ b/public/js/games-common.js
@@ -1,0 +1,35 @@
+(function(){
+  let cache = null;
+
+  async function loadVocab(){
+    if(cache) return cache;
+    const res = await fetch('/data/vocab.json');
+    const data = await res.json();
+    const all=[];
+    for(const [group,arr] of Object.entries(data)){
+      arr.forEach(item=>all.push({...item, group}));
+    }
+    cache = all;
+    return all;
+  }
+
+  async function getRandomEntries(count){
+    const vocab = await loadVocab();
+    const arr = [...vocab];
+    shuffle(arr);
+    return arr.slice(0,count);
+  }
+
+  function getLang(){
+    return localStorage.getItem('lang') || 'es';
+  }
+
+  function shuffle(arr){
+    for(let i=arr.length-1;i>0;i--){
+      const j=Math.floor(Math.random()*(i+1));
+      [arr[i],arr[j]]=[arr[j],arr[i]];
+    }
+  }
+
+  window.gamesCommon = {loadVocab, getRandomEntries, getLang, shuffle};
+})();

--- a/public/js/include.js
+++ b/public/js/include.js
@@ -4,7 +4,8 @@ document.addEventListener("DOMContentLoaded", function () {
   // Determinar si estamos en una subcarpeta
   const base = path.includes("/lection/") ||
                path.includes("/appendice/") ||
-               path.includes("/lessons/")
+               path.includes("/lessons/") ||
+               path.includes("/games/")
     ? "../components/"
     : "components/";
 


### PR DESCRIPTION
## Summary
- Add "Juegos" link in navbar and load components from game pages
- Implement shared utilities in `games-common.js` for random vocab and language handling
- Build five vocabulary mini-games and index page under `/games`
- Add basic styles for game layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc1440cc832ca5f794885da0a30d