### PR TITLE
Add React widget to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Un sincere gratias anque a tote illes que contribue a meliorar iste repositorio 
 
 ### Hospite del projecto
 Iste projecto es actualmente hospitate in vercel.com, un platforma moderne pro le distribution de applicationes web.
+
+### Tecnologias
+Le interfacie incorpora componentes rendite con [React](https://reactjs.org) pro adder un tocco moderne al sito sin necessitate de un processo de compilation.

--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,8 @@
       </p>
     </section>
 
+    <div id="react-root"></div>
+
     <!-- Sección Appendice -->
     <section id="appendix-section" class="card" style="display:none;">
       <h2>Appendice</h2>
@@ -64,6 +66,9 @@
   <footer></footer>
 
   <!-- Scripts -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="js/react-app.js"></script>
   <script src="js/include.js"></script>
   <script src="js/nav.js"></script>
   <script src="js/tooltip.js"></script>

--- a/public/js/react-app.js
+++ b/public/js/react-app.js
@@ -1,0 +1,18 @@
+const { useState } = React;
+
+function WelcomeWidget() {
+  const [count, setCount] = useState(0);
+  return (
+    React.createElement('div', { className: 'card' },
+      React.createElement('h2', null, 'React in Schola Interlingua'),
+      React.createElement('p', null, `Clics: ${count}`),
+      React.createElement('button', { className: 'btn btn-primary', onClick: () => setCount(count + 1) }, 'Clicar')
+    )
+  );
+}
+
+const rootElement = document.getElementById('react-root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(React.createElement(WelcomeWidget));
+}


### PR DESCRIPTION
## Summary
- Introduce CDN-powered React and root container on the home page
- Render a small interactive React widget for a modern feel
- Document React usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68978a3a304c832ca55ec520b86e01a0