### PR TITLE
feat: modernize design with React theme toggle

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -6,6 +6,13 @@
   --radius: 8px;
 }
 
+body[data-theme='dark'] {
+  --primary-color: #4dabf7;
+  --bg-color: #1e1e1e;
+  --text-color: #f5f5f5;
+  --card-bg: #2c2c2c;
+}
+
 /* Reset y base */
 * {
   box-sizing: border-box;
@@ -13,9 +20,10 @@
   padding: 0;
 }
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   background: var(--bg-color);
   color: var(--text-color);
+  transition: background 0.3s ease, color 0.3s ease;
 }
 img {
   max-width: 100%;
@@ -24,6 +32,13 @@ img {
 a {
   text-decoration: none;
   color: inherit;
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
 }
 
 /* Botones reutilizables */
@@ -61,7 +76,7 @@ a {
 
 /* Header y navegación */
 header {
-  background: var(--primary-color);
+  background: linear-gradient(90deg, var(--primary-color), #4a90e2);
   padding: 1rem;
   border-radius: 0 0 var(--radius) var(--radius);
 }
@@ -131,6 +146,7 @@ main {
   border-radius: var(--radius);
   box-shadow: 0 2px 6px rgba(0,0,0,0.05);
   margin-bottom: 2rem;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 h2 {
   margin-bottom: 1rem;

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <title>Schola Interlingua</title>
@@ -14,6 +15,7 @@
 </head>
 <body>
   <nav></nav>
+  <div id="react-root" class="theme-toggle"></div>
 
   <main>
     <section id="progress-section" class="card">
@@ -98,6 +100,10 @@
       }
     });
   </script>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel" src="js/react-app.js"></script>
 </body>
 </html>
 

--- a/public/js/react-app.js
+++ b/public/js/react-app.js
@@ -1,0 +1,20 @@
+const { useState, useEffect } = React;
+
+function ThemeToggle() {
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
+
+  useEffect(() => {
+    document.body.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
+
+  return (
+    <button className="btn btn-primary" onClick={toggle}>
+      {theme === 'light' ? 'Modo oscuro' : 'Modo claro'}
+    </button>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('react-root')).render(<ThemeToggle />);


### PR DESCRIPTION
## Summary
- refresh styles with Inter font, gradient header, and dark-mode variables
- add React-powered theme toggle using CDN-loaded React and Babel
- smooth card transitions for a more modern look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb30edfd8832cba347361f3186584