### PR TITLE
feat: scaffold modern React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.dist
+vite.config.js.timestamp
+.DS_Store
+dist
+
+# Legacy site
+public/**
+!public/README.md

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Schola Interlingua</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=JetBrains+Mono:wght@400;700&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+  </head>
+  <body class="font-sans antialiased bg-gray-50 text-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "schola-interlingua-react",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests configured'"
+  },
+  "dependencies": {
+    "framer-motion": "^11.0.0",
+    "lucide-react": "^0.426.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,21 @@
+import Header from './components/Header.jsx';
+import Hero from './components/Hero.jsx';
+import Features from './components/Features.jsx';
+import Progress from './components/Progress.jsx';
+import Course from './components/Course.jsx';
+import Footer from './components/Footer.jsx';
+
+function App() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <Hero />
+      <Features />
+      <Progress />
+      <Course />
+      <Footer />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/Course.jsx
+++ b/src/components/Course.jsx
@@ -1,0 +1,10 @@
+const Course = () => (
+  <section className="py-16 bg-gray-50">
+    <div className="max-w-5xl mx-auto px-4 text-center space-y-4">
+      <h2 className="font-heading text-2xl">Curso</h2>
+      <p className="text-gray-600">Explora las lecciones disponibles.</p>
+    </div>
+  </section>
+);
+
+export default Course;

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,0 +1,21 @@
+import { Book, Award, Zap } from 'lucide-react';
+
+const features = [
+  { icon: Book, title: 'Lecciones Modernas' },
+  { icon: Award, title: 'Seguimiento de Progreso' },
+  { icon: Zap, title: 'Interactividad' },
+];
+
+const Features = () => (
+  <section className="py-16 max-w-5xl mx-auto px-4 grid gap-8 md:grid-cols-3">
+    {features.map(({ icon: Icon, title }) => (
+      <div key={title} className="text-center space-y-3">
+        <Icon className="mx-auto text-primary" size={32} />
+        <h3 className="font-heading">{title}</h3>
+        <p className="text-sm text-gray-600">Descripción breve de {title.toLowerCase()}.</p>
+      </div>
+    ))}
+  </section>
+);
+
+export default Features;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+const Footer = () => (
+  <footer className="py-8 bg-gray-800 text-gray-300 text-center mt-auto">
+    <p>© {new Date().getFullYear()} Schola Interlingua</p>
+  </footer>
+);
+
+export default Footer;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,17 @@
+import { Menu } from 'lucide-react';
+
+const Header = () => (
+  <header className="sticky top-0 backdrop-blur bg-white/70 shadow-sm z-10">
+    <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+      <span className="font-heading text-xl text-primary">Schola</span>
+      <Menu className="md:hidden" />
+      <nav className="hidden md:flex gap-6 text-sm">
+        <a href="#" className="hover:text-primary">Inicio</a>
+        <a href="#" className="hover:text-primary">Curso</a>
+        <a href="#" className="hover:text-primary">Progreso</a>
+      </nav>
+    </div>
+  </header>
+);
+
+export default Header;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,30 @@
+import { motion } from 'framer-motion';
+
+const Hero = () => (
+  <section className="text-center py-24 bg-gradient-to-br from-primary to-secondary text-white">
+    <motion.h1
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="text-4xl font-heading mb-6"
+    >
+      Aprende Interlingua Modernamente
+    </motion.h1>
+    <motion.p
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.2 }}
+      className="max-w-xl mx-auto mb-8"
+    >
+      Plataforma interactiva para dominar el idioma de forma rápida y divertida.
+    </motion.p>
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className="bg-accent px-6 py-3 rounded-full font-semibold shadow-lg"
+    >
+      Comenzar
+    </motion.button>
+  </section>
+);
+
+export default Hero;

--- a/src/components/Progress.jsx
+++ b/src/components/Progress.jsx
@@ -1,0 +1,10 @@
+const Progress = () => (
+  <section className="py-16 bg-white">
+    <div className="max-w-5xl mx-auto px-4 text-center space-y-4">
+      <h2 className="font-heading text-2xl">Tu Progreso</h2>
+      <p className="text-gray-600">Próximamente: dashboard interactivo.</p>
+    </div>
+  </section>
+);
+
+export default Progress;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#2563eb',
+        secondary: '#7e22ce',
+        accent: '#fb923c',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        heading: ['Poppins', 'sans-serif'],
+        mono: ['JetBrains Mono', 'monospace'],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React 18 app with Vite and Tailwind
- add reusable layout components with Lucide icons and Framer Motion
- set up custom color palette and typography

## Testing
- `npm install` *(fails: 403 Forbidden to npm registry)*
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc3c55758832c84527e9926023172