### PR TITLE
feat: add theme toggle to navbar

### DIFF
--- a/public/components/navbar.html
+++ b/public/components/navbar.html
@@ -4,46 +4,51 @@
       <img src="/images/logo.png" alt="Logo Schola Interlingua" class="logo">
       <span class="brand-text">Schola Interlingua</span>
     </a>
-    <ul class="nav-links">
-      <li class="dropdown">
-        <a href="#">Lectiones ▼</a>
-        <ul class="dropdown-menu">
-          <li><a href="/lection/lection1.html">Lection 1</a></li>
-          <li><a href="/lection/lection2.html">Lection 2</a></li>
-          <li><a href="/lection/lection3.html">Lection 3</a></li>
-          <li><a href="/lection/lection4.html">Lection 4</a></li>
-          <li><a href="/lection/lection5.html">Lection 5</a></li>
-          <li><a href="/lection/lection6.html">Lection 6</a></li>
-          <li><a href="/lection/lection7.html">Lection 7</a></li>
-          <li><a href="/lection/lection8.html">Lection 8</a></li>
-          <li><a href="/lection/lection9.html">Lection 9</a></li>
-          <li><a href="/lection/lection10.html">Lection 10</a></li>
-        </ul>
-      </li>
-      <li class="dropdown">
-        <a href="#">Appendice ▼</a>
-        <ul class="dropdown-menu">
-          <li><a href="/appendice/grammatica.html">Breve grammatica</a></li>
-          <li><a href="/appendice/numeros.html">Numeros</a></li>
-          <li><a href="/appendice/contos.html">Contos legite</a></li>
-        </ul>
-      </li>
-      <li class="dropdown">
-        <a href="#">Linguas ▼</a>
-        <ul class="dropdown-menu">
-          <li><a href="#" class="lang-option" data-lang="es">Español</a></li>
-          <li><a href="#" class="lang-option" data-lang="en">English</a></li>
-          <li><a href="#" class="lang-option" data-lang="ru">Русский</a></li>
-          <li><a href="#" class="lang-option" data-lang="de">Deutsch</a></li>
-          <li><a href="#" class="lang-option" data-lang="fr">Français</a></li>
-          <li><a href="#" class="lang-option" data-lang="it">Italiano</a></li>
-          <li><a href="#" class="lang-option" data-lang="pt">Português</a></li>
-          <li><a href="#" class="lang-option" data-lang="zh">中文</a></li>
-          <li><a href="#" class="lang-option" data-lang="ja">日本語</a></li>
-          <li><a href="#" class="lang-option" data-lang="ca">Català</a></li>
-          <li><a href="#" class="lang-option" data-lang="ko">한국어</a></li>
-        </ul>
-      </li>
-    </ul>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li class="dropdown">
+          <a href="#">Lectiones ▼</a>
+          <ul class="dropdown-menu">
+            <li><a href="/lection/lection1.html">Lection 1</a></li>
+            <li><a href="/lection/lection2.html">Lection 2</a></li>
+            <li><a href="/lection/lection3.html">Lection 3</a></li>
+            <li><a href="/lection/lection4.html">Lection 4</a></li>
+            <li><a href="/lection/lection5.html">Lection 5</a></li>
+            <li><a href="/lection/lection6.html">Lection 6</a></li>
+            <li><a href="/lection/lection7.html">Lection 7</a></li>
+            <li><a href="/lection/lection8.html">Lection 8</a></li>
+            <li><a href="/lection/lection9.html">Lection 9</a></li>
+            <li><a href="/lection/lection10.html">Lection 10</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a href="#">Appendice ▼</a>
+          <ul class="dropdown-menu">
+            <li><a href="/appendice/grammatica.html">Breve grammatica</a></li>
+            <li><a href="/appendice/numeros.html">Numeros</a></li>
+            <li><a href="/appendice/contos.html">Contos legite</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a href="#">Linguas ▼</a>
+          <ul class="dropdown-menu">
+            <li><a href="#" class="lang-option" data-lang="es">Español</a></li>
+            <li><a href="#" class="lang-option" data-lang="en">English</a></li>
+            <li><a href="#" class="lang-option" data-lang="ru">Русский</a></li>
+            <li><a href="#" class="lang-option" data-lang="de">Deutsch</a></li>
+            <li><a href="#" class="lang-option" data-lang="fr">Français</a></li>
+            <li><a href="#" class="lang-option" data-lang="it">Italiano</a></li>
+            <li><a href="#" class="lang-option" data-lang="pt">Português</a></li>
+            <li><a href="#" class="lang-option" data-lang="zh">中文</a></li>
+            <li><a href="#" class="lang-option" data-lang="ja">日本語</a></li>
+            <li><a href="#" class="lang-option" data-lang="ca">Català</a></li>
+            <li><a href="#" class="lang-option" data-lang="ko">한국어</a></li>
+          </ul>
+        </li>
+      </ul>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar a modo oscuro">
+        <i class="fas fa-moon"></i>
+      </button>
+    </div>
   </div>
 </header>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -6,6 +6,12 @@
   --radius: 8px;
 }
 
+body.dark-mode {
+  --bg-color: #1e1e1e;
+  --text-color: #eee;
+  --card-bg: #2c2c2c;
+}
+
 /* Reset y base */
 * {
   box-sizing: border-box;
@@ -72,6 +78,11 @@ header {
   align-items: center;
   justify-content: space-between;
 }
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
 .nav-brand {
   color: #fff;
   font-size: 1.25rem;
@@ -116,6 +127,14 @@ header {
 }
 .dropdown-menu li a:hover {
   background: var(--bg-color);
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.2rem;
 }
 
 /* Main */

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -65,11 +65,41 @@ function buildCursoLink() {
   else navLinks.appendChild(li);
 }
 
+function initThemeToggle() {
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  const icon = btn.querySelector('i');
+
+  function setTheme(mode) {
+    if (mode === 'dark') {
+      document.body.classList.add('dark-mode');
+      icon.classList.remove('fa-moon');
+      icon.classList.add('fa-sun');
+      btn.setAttribute('aria-label', 'Cambiar a modo claro');
+    } else {
+      document.body.classList.remove('dark-mode');
+      icon.classList.remove('fa-sun');
+      icon.classList.add('fa-moon');
+      btn.setAttribute('aria-label', 'Cambiar a modo oscuro');
+    }
+  }
+
+  const saved = localStorage.getItem('theme') || 'light';
+  setTheme(saved);
+
+  btn.addEventListener('click', () => {
+    const newMode = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+    localStorage.setItem('theme', newMode);
+    setTheme(newMode);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const timer = setInterval(() => {
     if (document.querySelector('.nav-links')) {
       clearInterval(timer);
       buildCursoLink();
+      initThemeToggle();
     }
   }, 50);
 });


### PR DESCRIPTION
## Summary
- add dark mode toggle button with icon to navbar
- support dark theme variables and styling
- persist theme selection using localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc809c990832c91a06312ce0cf923