### PR TITLE
Add games section to site

### DIFF
--- a/public/components/navbar.html
+++ b/public/components/navbar.html
@@ -22,6 +22,16 @@
           </ul>
         </li>
         <li class="dropdown">
+          <a href="#">Juegos ▼</a>
+          <ul class="dropdown-menu">
+            <li><a href="/games/memory.html">Parejas</a></li>
+            <li><a href="/games/fill-blank.html">Completar huecos</a></li>
+            <li><a href="/games/match.html">Unir pares</a></li>
+            <li><a href="/games/odd-one.html">El intruso</a></li>
+            <li><a href="/games/wordsearch.html">Sopa de letras</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
           <a href="#">Appendice ▼</a>
           <ul class="dropdown-menu">
             <li><a href="/appendice/grammatica.html">Breve grammatica</a></li>

--- a/public/games/fill-blank.html
+++ b/public/games/fill-blank.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Completar huecos - Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <h1>Completar huecos</h1>
+    <button class="btn btn-secondary" onclick="location.href='/games/index.html'">Volver a Juegos</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/games/index.html
+++ b/public/games/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Juegos - Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <h1>Juegos</h1>
+    <ul>
+      <li><a href="/games/memory.html">Parejas</a></li>
+      <li><a href="/games/fill-blank.html">Completar huecos</a></li>
+      <li><a href="/games/match.html">Unir pares</a></li>
+      <li><a href="/games/odd-one.html">El intruso</a></li>
+      <li><a href="/games/wordsearch.html">Sopa de letras</a></li>
+    </ul>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/games/match.html
+++ b/public/games/match.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Unir pares - Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <h1>Unir pares</h1>
+    <button class="btn btn-secondary" onclick="location.href='/games/index.html'">Volver a Juegos</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/games/memory.html
+++ b/public/games/memory.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Parejas - Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <h1>Parejas</h1>
+    <button class="btn btn-secondary" onclick="location.href='/games/index.html'">Volver a Juegos</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/games/odd-one.html
+++ b/public/games/odd-one.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>El intruso - Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <h1>El intruso</h1>
+    <button class="btn btn-secondary" onclick="location.href='/games/index.html'">Volver a Juegos</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/games/wordsearch.html
+++ b/public/games/wordsearch.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <link rel="icon" href="/icons/favicon.ico" type="image/x-icon">
+  <title>Sopa de letras - Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <h1>Sopa de letras</h1>
+    <button class="btn btn-secondary" onclick="location.href='/games/index.html'">Volver a Juegos</button>
+  </main>
+  <footer></footer>
+  <script src="/js/include.js"></script>
+  <script src="/js/nav.js"></script>
+  <script src="/js/games-common.js"></script>
+</body>
+</html>

--- a/public/js/games-common.js
+++ b/public/js/games-common.js
@@ -1,0 +1,31 @@
+// Utility functions and vocabulary loader for games
+(function(){
+  const LANG = localStorage.getItem('lang') || 'es';
+  window.LANG = LANG;
+
+  async function loadVocab() {
+    try {
+      const res = await fetch('/data/vocab.json');
+      window.VOCAB = await res.json();
+    } catch (err) {
+      console.error('Error loading vocab:', err);
+      window.VOCAB = [];
+    }
+  }
+  loadVocab();
+
+  function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+  }
+
+  function sample(array, n) {
+    return shuffle(array.slice()).slice(0, n);
+  }
+
+  window.shuffle = shuffle;
+  window.sample = sample;
+})();

--- a/public/js/include.js
+++ b/public/js/include.js
@@ -4,7 +4,8 @@ document.addEventListener("DOMContentLoaded", function () {
   // Determinar si estamos en una subcarpeta
   const base = path.includes("/lection/") ||
                path.includes("/appendice/") ||
-               path.includes("/lessons/")
+               path.includes("/lessons/") ||
+               path.includes("/games/")
     ? "../components/"
     : "components/";
 


### PR DESCRIPTION
## Summary
- add "Juegos" dropdown in navbar with links to five games
- load navbar/footer on game pages and add shared games utilities
- scaffold static pages for Parejas, Completar huecos, Unir pares, El intruso and Sopa de letras

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fa63390832cb0422948945ca71f