### PR TITLE
Fix tooltip translations in wordsearch instructions

### DIFF
--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -1,36 +1,54 @@
-// Agrega tooltips de traducción a todos los textos de las lecciones
+// Agrega tooltips de traducción a textos de la web y actualiza al cambiar el idioma
 
-document.addEventListener('DOMContentLoaded', () => {
-  const lang = localStorage.getItem('lang') || 'es';
-  // Cargar vocabulario
-  fetch('/data/vocab.json')
-    .then(res => res.json())
+let cachedVocab = null;
+
+function applyTooltips(lang) {
+  const selector = '.text-block p, .text-block li, .grammar p, #home-section p, .grammar li, .card p, .vocab-table li';
+
+  const loadVocab = cachedVocab
+    ? Promise.resolve(cachedVocab)
+    : fetch('/data/vocab.json').then(res => res.json()).then(data => {
+        cachedVocab = data;
+        return data;
+      });
+
+  loadVocab
     .then(data => {
       const vocab = {};
       // Unir todas las lecciones en un solo objeto de búsqueda
       Object.values(data).forEach(arr => {
         if (Array.isArray(arr)) {
           arr.forEach(item => {
-            const translation = item[lang] || item.es;
+            const translation = item[lang] || item.en || item.es || item.term;
             vocab[item.term.toLowerCase()] = translation;
           });
         }
       });
 
-      const elements = document.querySelectorAll('.text-block p, .grammar p, #home-section p, .grammar li, .card p, .vocab-table li');
-      elements.forEach(el => {
+      document.querySelectorAll(selector).forEach(el => {
         const tokens = el.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
-        const html = tokens.map(tok => {
-          const clean = tok.replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
-          if (vocab[clean]) {
+        const html = tokens
+          .map(tok => {
+            const clean = tok.replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
             const translation = vocab[clean];
-            return `<span class="tooltip" aria-label="${translation}">${tok}<span class="tooltiptext">${translation}</span></span>`;
-          }
-          return tok;
-        }).join('');
-
+            if (translation) {
+              return `<span class="tooltip" aria-label="${translation}">${tok}<span class="tooltiptext">${translation}</span></span>`;
+            }
+            return tok;
+          })
+          .join('');
         el.innerHTML = html;
       });
     })
     .catch(err => console.error('No se pudo cargar el vocabulario:', err));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const lang = localStorage.getItem('lang') || 'es';
+  applyTooltips(lang);
+});
+
+// Actualizar tooltips cuando cambia el idioma
+document.addEventListener('langChanged', e => {
+  applyTooltips(e.detail.newLang);
 });


### PR DESCRIPTION
## Summary
- Enhance tooltip script to include list items in text blocks
- Refresh tooltips when the navbar language changes and cache vocabulary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a635c51ff0832cb51b98026a10d202