### PR TITLE
Fix tooltip translations in wordsearch

### DIFF
--- a/public/games/wordsearch.html
+++ b/public/games/wordsearch.html
@@ -526,7 +526,7 @@
             
             try {
                 const vocab = await GamesCommon.loadVocab();
-                const lang = GamesCommon.getLang();
+                const lang = localStorage.getItem('lang') || GamesCommon.getLang();
                 
                 gameState.words.forEach(word => {
                     const wordElement = document.createElement('div');
@@ -558,6 +558,8 @@
                     
                     wordsContainer.appendChild(wordElement);
                 });
+
+                await applyTooltips();
             } catch (error) {
                 console.error('Error cargando traducciones:', error);
                 // Fallback sin tooltips

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -1,36 +1,46 @@
 // Agrega tooltips de traducción a todos los textos de las lecciones
 
-document.addEventListener('DOMContentLoaded', () => {
-  const lang = localStorage.getItem('lang') || 'es';
-  // Cargar vocabulario
-  fetch('/data/vocab.json')
-    .then(res => res.json())
-    .then(data => {
-      const vocab = {};
-      // Unir todas las lecciones en un solo objeto de búsqueda
-      Object.values(data).forEach(arr => {
-        if (Array.isArray(arr)) {
-          arr.forEach(item => {
-            const translation = item[lang] || item.es;
-            vocab[item.term.toLowerCase()] = translation;
-          });
+let tooltipVocabCache = null;
+
+async function applyTooltips() {
+  const lang = localStorage.getItem('lang') || (window.GamesCommon && GamesCommon.getLang()) || 'es';
+
+  try {
+    if (!tooltipVocabCache) {
+      const res = await fetch('/data/vocab.json');
+      tooltipVocabCache = await res.json();
+    }
+
+    const vocab = {};
+    // Unir todas las lecciones en un solo objeto de búsqueda
+    Object.values(tooltipVocabCache).forEach(arr => {
+      if (Array.isArray(arr)) {
+        arr.forEach(item => {
+          const translation = item[lang] || item.en || item.es || item.term;
+          vocab[item.term.toLowerCase()] = translation;
+        });
+      }
+    });
+
+    const selector = '.text-block p, .text-block li, .grammar p, #home-section p, .grammar li, .card p, .vocab-table li';
+    const elements = document.querySelectorAll(selector);
+    elements.forEach(el => {
+      const tokens = el.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
+      const html = tokens.map(tok => {
+        const clean = tok.replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
+        if (vocab[clean]) {
+          const translation = vocab[clean];
+          return `<span class="tooltip" aria-label="${translation}">${tok}<span class="tooltiptext">${translation}</span></span>`;
         }
-      });
+        return tok;
+      }).join('');
 
-      const elements = document.querySelectorAll('.text-block p, .grammar p, #home-section p, .grammar li, .card p, .vocab-table li');
-      elements.forEach(el => {
-        const tokens = el.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
-        const html = tokens.map(tok => {
-          const clean = tok.replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
-          if (vocab[clean]) {
-            const translation = vocab[clean];
-            return `<span class="tooltip" aria-label="${translation}">${tok}<span class="tooltiptext">${translation}</span></span>`;
-          }
-          return tok;
-        }).join('');
+      el.innerHTML = html;
+    });
+  } catch (err) {
+    console.error('No se pudo cargar el vocabulario:', err);
+  }
+}
 
-        el.innerHTML = html;
-      });
-    })
-    .catch(err => console.error('No se pudo cargar el vocabulario:', err));
-});
+document.addEventListener('DOMContentLoaded', applyTooltips);
+document.addEventListener('langChanged', applyTooltips);


### PR DESCRIPTION
## Summary
- Ensure tooltip.js uses the locally selected language before falling back
- Re-render wordsearch vocabulary with proper language and apply tooltips after populating

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4422d34832cbcceff95fd2a8bc1