### PR TITLE
Fix language initialization and tooltip for lists

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1181,6 +1181,11 @@ body.dark-mode .tooltiptext {
   border-color: var(--border-color);
 }
 
+body.dark-mode .tooltip,
+body.dark-mode .tooltip:hover {
+  border-bottom-color: #fff;
+}
+
 body.dark-mode #audio {
   background: var(--bg-secondary);
   border-color: var(--border-color);

--- a/public/js/games-common.js
+++ b/public/js/games-common.js
@@ -2,7 +2,7 @@
 
 // Configuración global
 let vocabCache = null;
-let currentLang = 'es';
+let currentLang = null;
 
 // Función para cargar y cachear el vocabulario
 async function loadVocab() {
@@ -25,7 +25,7 @@ async function loadVocab() {
 
 // Función para obtener el idioma activo
 function getLang() {
-    if (!currentLang) {
+    if (currentLang == null) {
         currentLang = localStorage.getItem('lang') || 'es';
     }
     return currentLang;

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
 
-      const elements = document.querySelectorAll('.text-block p, .grammar p, #home-section p, .grammar li, .card p, .vocab-table li');
+      const elements = document.querySelectorAll('.text-block p, .text-block li, .grammar p, #home-section p, .grammar li, .card p, .vocab-table li');
       elements.forEach(el => {
         const tokens = el.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
         const html = tokens.map(tok => {


### PR DESCRIPTION
## Summary
- Use stored language at game startup instead of defaulting to Spanish
- Apply vocabulary tooltips to list items within text blocks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9102174832cb69b48500048a608