### PR TITLE
Add interactive readings section with vocabulary tooltips

### DIFF
--- a/public/components/navbar.html
+++ b/public/components/navbar.html
@@ -22,6 +22,21 @@
           </ul>
         </li>
         <li class="dropdown">
+          <a href="#">Lege ▼</a>
+          <ul class="dropdown-menu">
+            <li><a href="/lecturas/mi-familia.html">Mi familia</a></li>
+            <li><a href="/lecturas/un-die-in-scola.html">Un die in scola</a></li>
+            <li><a href="/lecturas/un-visita-al-mercato.html">Un visita al mercato</a></li>
+            <li><a href="/lecturas/un-excursion-al-parco.html">Un excursion al parco</a></li>
+            <li><a href="/lecturas/le-casa-de-libros.html">Le casa de libros</a></li>
+            <li><a href="/lecturas/un-viage-in-tren.html">Un viage in tren</a></li>
+            <li><a href="/lecturas/le-inventores.html">Le inventores</a></li>
+            <li><a href="/lecturas/le-linguas-del-mundo.html">Le linguas del mundo</a></li>
+            <li><a href="/lecturas/proque-interlingua-es-utile.html">Proque Interlingua es utile</a></li>
+            <li><a href="/lecturas/un-futuro-interlingual.html">Un futuro interlingual</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
           <a href="#">Appendice ▼</a>
           <ul class="dropdown-menu">
             <li><a href="/appendice/grammatica.html">Breve grammatica</a></li>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -305,7 +305,9 @@ header {
   }
 }
 
-.dropdown:hover .dropdown-menu {
+.dropdown:hover .dropdown-menu,
+.dropdown:focus-within .dropdown-menu,
+.dropdown.open .dropdown-menu {
   display: block;
 }
 

--- a/public/js/include.js
+++ b/public/js/include.js
@@ -5,7 +5,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const base = path.includes("/lection/") ||
                path.includes("/appendice/") ||
                path.includes("/lessons/") ||
-               path.includes("/games/")
+               path.includes("/games/") ||
+               path.includes("/lecturas/")
     ? "../components/"
     : "components/";
 

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -94,12 +94,33 @@ function initThemeToggle() {
   });
 }
 
+function initDropdownAccessibility() {
+  document.querySelectorAll('.dropdown > a').forEach(trigger => {
+    trigger.addEventListener('click', e => e.preventDefault());
+    trigger.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        trigger.blur();
+      }
+    });
+  });
+  document.querySelectorAll('.dropdown-menu a').forEach(item => {
+    item.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        const parent = item.closest('.dropdown');
+        const link = parent && parent.querySelector('a');
+        if (link) link.focus();
+      }
+    });
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const timer = setInterval(() => {
     if (document.querySelector('.nav-links')) {
       clearInterval(timer);
       buildCursoLink();
       initThemeToggle();
+      initDropdownAccessibility();
     }
   }, 50);
 });

--- a/public/js/readings.js
+++ b/public/js/readings.js
@@ -1,0 +1,24 @@
+// Procesa textos de lecturas para agregar tooltips por palabra
+(function() {
+  function wrapWords() {
+    document.querySelectorAll('[data-tooltips]').forEach(node => {
+      const tokens = node.textContent.match(/\w+|\s+|[^\s\w]+/g) || [];
+      node.innerHTML = tokens.map(tok => {
+        return /\w+/.test(tok)
+          ? `<span class="tiw" data-term="${tok}">${tok}</span>`
+          : tok;
+      }).join('');
+    });
+    const lang = window.getSelectedLang?.();
+    if (window.Tooltip && window.VOCAB) {
+      window.Tooltip.init('.tiw', window.VOCAB, lang);
+    }
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.VOCAB) {
+      wrapWords();
+    } else {
+      document.addEventListener('vocab-loaded', wrapWords, { once: true });
+    }
+  });
+})();

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -1,13 +1,31 @@
-// Agrega tooltips de traducción a todos los textos de las lecciones
+// Biblioteca de tooltips reutilizable
+window.Tooltip = {
+  init(selector, vocab, lang) {
+    const current = lang || window.getSelectedLang?.() || localStorage.getItem('lang') || 'es';
+    document.querySelectorAll(selector).forEach(el => {
+      const key = (el.dataset.term || '').replace(/[^\wáéíóúüñ]/gi, '').toLowerCase();
+      const item = vocab[key];
+      if (!item) return;
+      const translation = item[current] || item.es || '';
+      const span = document.createElement('span');
+      span.className = 'tooltip';
+      span.textContent = el.textContent;
+      const tt = document.createElement('span');
+      tt.className = 'tooltiptext';
+      tt.textContent = translation;
+      span.appendChild(tt);
+      el.replaceWith(span);
+    });
+  }
+};
 
+// Agrega tooltips de traducción a textos existentes del sitio
 document.addEventListener('DOMContentLoaded', () => {
   const lang = localStorage.getItem('lang') || 'es';
-  // Cargar vocabulario
   fetch('/data/vocab.json')
     .then(res => res.json())
     .then(data => {
       const vocab = {};
-      // Unir todas las lecciones en un solo objeto de búsqueda
       Object.values(data).forEach(arr => {
         if (Array.isArray(arr)) {
           arr.forEach(item => {

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -21,6 +21,10 @@ window.Tooltip = {
 
 // Agrega tooltips de traducción a textos existentes del sitio
 document.addEventListener('DOMContentLoaded', () => {
+  // Si la página usa el nuevo sistema de data-tooltips (lecturas),
+  // evitamos reprocesar el contenido para no duplicar o esconder texto.
+  if (document.querySelector('[data-tooltips]')) return;
+
   const lang = localStorage.getItem('lang') || 'es';
   fetch('/data/vocab.json')
     .then(res => res.json())

--- a/public/js/vocab.js
+++ b/public/js/vocab.js
@@ -1,0 +1,24 @@
+// Carga el vocabulario global y lo expone como window.VOCAB
+// Emite el evento 'vocab-loaded' cuando está listo
+(function() {
+  function load() {
+    fetch('/data/vocab.json')
+      .then(res => res.json())
+      .then(data => {
+        const vocab = {};
+        Object.values(data).forEach(arr => {
+          if (Array.isArray(arr)) {
+            arr.forEach(item => {
+              vocab[item.term.toLowerCase()] = item;
+            });
+          }
+        });
+        window.VOCAB = vocab;
+        document.dispatchEvent(new Event('vocab-loaded'));
+      })
+      .catch(err => console.error('No se pudo cargar el vocabulario:', err));
+  }
+  if (!window.VOCAB) {
+    document.addEventListener('DOMContentLoaded', load);
+  }
+})();

--- a/public/lecturas/le-casa-de-libros.html
+++ b/public/lecturas/le-casa-de-libros.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Le casa de libros — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Le casa de libros</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Le bibliotheca es un grande casa de libros. Intra, il ha silenti e lumine suave. Le libros conta historias de aventura, de scientia e de amores antique. Un studente lege pro studiar historia, un femina consulta un dictionario, e un senior lege poesia. Le bibliotheca es un tresor pro tote qui ama apprender.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/le-inventores.html
+++ b/public/lecturas/le-inventores.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Le inventores — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Le inventores</h1>
+      <article class="reading-body" data-tooltips>
+        <p>In le historia, multe inventores cambiava le vita human. Illes creava instrumentos pro scriber, pro viagiar, e pro communicar. Le horologio, le libro imprimite, e le telephono es invention que uni personas. Cata invention nasce de un idea simple que cresce con tempore.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/le-linguas-del-mundo.html
+++ b/public/lecturas/le-linguas-del-mundo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Le linguas del mundo — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Le linguas del mundo</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Il ha milles de linguas in le mundo. Alcunes es grande, con milliones de parlatores; alteres es parve, con solmente alcun communitates. Linguas es como fenestras al cultura: illas monstra como un populo pensa e vive. Apprender linguas aperi le mente e uni le personas.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/mi-familia.html
+++ b/public/lecturas/mi-familia.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Mi familia — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Mi familia</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Isto es mi familia. Mi matre se appella Laura e mi patre se appella Marco. Io ha un fratre e un soror. Nos vive in un casa con un parve jardin. Nos mangia insimul, parla insimul e ride multo. Io ama mi familia.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/proque-interlingua-es-utile.html
+++ b/public/lecturas/proque-interlingua-es-utile.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Proque Interlingua es utile — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Proque Interlingua es utile</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Interlingua es un lingua simple, ma potente. Illa prende le parolas commun del linguas europee e crea un systema clar e logic. Un persona pote leger e comprender rapide, mesmo sin studiar multe annos. Con Interlingua, un italiano, un francese e un hispanico pote communicar sin difficultate. Isto lingua es un ponte practic inter culturas.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/un-die-in-scola.html
+++ b/public/lecturas/un-die-in-scola.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Un die in scola — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Un die in scola</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Io vade a scola cata die. Mi classe ha multe fenestras e un tabula grande. Le magistro explica le lection, e nos responde. In le pausa, nos joca in le cortile. Le scola es un loco pro studiar e pro facer amicos.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/un-excursion-al-parco.html
+++ b/public/lecturas/un-excursion-al-parco.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Un excursion al parco — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Un excursion al parco</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Le parco es un loco tranquille in le citate. Il ha arbores alte, aves que canta e flores que cresce in primavera. Un familia face un picnic, un senior lege un libro, e pueros corre post un ballon. In le parco, le tempore passa plus lente, e le personas se senti serene.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/un-futuro-interlingual.html
+++ b/public/lecturas/un-futuro-interlingual.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Un futuro interlingual — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Un futuro interlingual</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Imaginemus un futuro ubi plus personas cognosce Interlingua. Studios scientific, libros e jornales pote esser legite sin traduction complexe. Viagiatores pote usar Interlingua pro trovar information in multe paises. Illa non substitue le linguas national, ma adde un lingua commun pro claritate e cooperation. Un futuro interlingual es un futuro de comprension plus facile.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/un-viage-in-tren.html
+++ b/public/lecturas/un-viage-in-tren.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Un viage in tren — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Un viage in tren</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Le tren parte del station con un grande son. Illo passa montanias, fluvios e campos verde. Alcun personas lege, alteres dormi, e pueros observa per le fenestras. Le viage in tren monstra como le mundo cambia rapide: un momento es citate, le proxime es natura.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>

--- a/public/lecturas/un-visita-al-mercato.html
+++ b/public/lecturas/un-visita-al-mercato.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <title>Un visita al mercato — Schola Interlingua</title>
+</head>
+<body>
+  <nav></nav>
+  <main>
+    <section class="card reading-container">
+      <h1 class="reading-title" data-tooltips>Un visita al mercato</h1>
+      <article class="reading-body" data-tooltips>
+        <p>Le sabbato io vade al mercato. Il ha fructos fresc, pan calide e flores colorate. Io compra tres pomos, duo bananos e un sacco de uvas. Le mercato es plen de vita: le venditores parla forte, le pueros ride, e le personas porta grande saccos.</p>
+      </article>
+    </section>
+  </main>
+  <footer></footer>
+  <script src="../js/include.js"></script>
+  <script src="../js/nav.js"></script>
+  <script src="../js/tooltip.js"></script>
+  <script src="../js/anki-all.js"></script>
+  <script src="../js/vocab.js"></script>
+  <script src="../js/readings.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add 10 reading pages in `/lecturas` with Interlingua texts, loading global styles and tooltip functionality.
- Introduce scripts to load vocabulary (`vocab.js`) and wrap words (`readings.js`), using a new `Tooltip.init` API for per-word translations.
- Extend navbar with a “Lege” dropdown and improve dropdown keyboard accessibility and component loading paths.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b21766de74832cbdd083afb598af67