### PR TITLE
Actualizar referencias de ilustraciones de lecturas a PNG

### DIFF
--- a/public/lecturas/le-casa-de-libros.html
+++ b/public/lecturas/le-casa-de-libros.html
@@ -36,7 +36,7 @@
           pote sentir le mesme fascino que io senti cata vice que io entra ibi.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-le-casa-de-libros.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-le-casa-de-libros.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/le-inventores.html
+++ b/public/lecturas/le-inventores.html
@@ -38,7 +38,7 @@
           mundo continua cambiar e progredir. Es per le inventores que le imagination deveni realitate.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-le-inventores.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-le-inventores.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/le-linguas-del-mundo.html
+++ b/public/lecturas/le-linguas-del-mundo.html
@@ -37,7 +37,7 @@
           mundo in le qual nos vive.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-le-linguas-del-mundo.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-le-linguas-del-mundo.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/mi-familia.html
+++ b/public/lecturas/mi-familia.html
@@ -39,7 +39,7 @@
           mundo.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-mi-familia.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-mi-familia.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/proque-interlingua-es-utile.html
+++ b/public/lecturas/proque-interlingua-es-utile.html
@@ -38,7 +38,7 @@
           accessible a omnes.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-proque-interlingua-es-utile.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-proque-interlingua-es-utile.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/un-die-in-scola.html
+++ b/public/lecturas/un-die-in-scola.html
@@ -37,7 +37,7 @@
           tempore con amicos. Cata die porta nove opportunitates de crescer e esser melior.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-un-die-in-scola.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-un-die-in-scola.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/un-excursion-al-parco.html
+++ b/public/lecturas/un-excursion-al-parco.html
@@ -34,7 +34,7 @@
           excursion al parco esseva simple, ma plen de gaudio, natura e tempore bon compartite con mi familia.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-un-excursion-al-parco.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-un-excursion-al-parco.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/un-futuro-interlingual.html
+++ b/public/lecturas/un-futuro-interlingual.html
@@ -40,7 +40,7 @@
           Interlingua, le mundo pote esser un poco plus unite.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-un-futuro-interlingual.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-un-futuro-interlingual.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/un-viage-in-tren.html
+++ b/public/lecturas/un-viage-in-tren.html
@@ -36,7 +36,7 @@
           in tren in le futuro!</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-un-viage-in-tren.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-un-viage-in-tren.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>

--- a/public/lecturas/un-visita-al-mercato.html
+++ b/public/lecturas/un-visita-al-mercato.html
@@ -39,7 +39,7 @@
           humor.</p>
       </article>
         <div class="image-block">
-          <img src="../images/lectura-un-visita-al-mercato.svg" alt="Ilustración de la lectura">
+          <img src="../images/lectura-un-visita-al-mercato.png" alt="Ilustración de la lectura">
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Actualizar las páginas de lectura para que utilicen las nuevas ilustraciones en formato `.png` en lugar de `.svg` para coincidir con los activos reemplazados.

### Description
- Reemplacé las extensiones `.svg` por `.png` en los atributos `src` de las etiquetas `<img>` en los archivos HTML de `public/lecturas` sin cambiar los nombres base ni las rutas.
- Archivos modificados: `public/lecturas/un-visita-al-mercato.html`, `public/lecturas/un-excursion-al-parco.html`, `public/lecturas/proque-interlingua-es-utile.html`, `public/lecturas/le-linguas-del-mundo.html`, `public/lecturas/un-viage-in-tren.html`, `public/lecturas/le-inventores.html`, `public/lecturas/un-die-in-scola.html`, `public/lecturas/le-casa-de-libros.html`, `public/lecturas/un-futuro-interlingual.html`, `public/lecturas/mi-familia.html`.

### Testing
- Ejecuté `rg -n "lectura-.*\.(svg|png)" public/lecturas -g '*.html'` para comprobar que las referencias `.svg` fueron reemplazadas por `.png` y la comprobación fue satisfactoria.
- Verifiqué la presencia de las nuevas referencias con `nl -ba public/lecturas/*.html | rg "lectura-.*\.png"`, que mostró las líneas actualizadas correctamente.
- Ejecuté `git status --short` para confirmar el estado del árbol de trabajo tras los cambios, sin discrepancias pendientes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699767280cf8832cafb940f8e48fbe3c)